### PR TITLE
Fix TypeError when field(init=False)

### DIFF
--- a/dacite.py
+++ b/dacite.py
@@ -188,10 +188,11 @@ def _inner_from_dict_for_collection(collection: Type[T], data: List[Data], outer
             config=_make_inner_config(field, outer_config),
         )) for key, value in data.items())
     else:
-        return collection_cls(from_dict(
+        return collection_cls(_inner_from_dict_for_dataclass(
             data_class=_extract_data_class(collection),
             data=item,
-            config=_make_inner_config(field, outer_config),
+            outer_config=outer_config,
+            field=field,
         ) for item in data)
 
 

--- a/dacite.py
+++ b/dacite.py
@@ -97,8 +97,8 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
             raise WrongTypeError(field, value)
         values[field.name] = value
 
-    init_values, post_init_value = _seperate_post_init(values, class_fields)
-    return _load_class(data_class, init_values, post_init_value)
+    init_values, post_init_values = _seperate_post_init(values, class_fields)
+    return _load_class(data_class, init_values, post_init_values)
 
 
 def _validate_config(data_class: Type[T], data: Data, config: Config):

--- a/dacite.py
+++ b/dacite.py
@@ -1,5 +1,5 @@
 from dataclasses import fields, MISSING, is_dataclass, Field, dataclass, field as dc_field
-from typing import Dict, Any, TypeVar, Type, Union, Callable, List, Collection, Optional, Set, Mapping, Tuple
+from typing import Dict, Any, TypeVar, Type, Union, Callable, List, Collection, Optional, Set, Mapping
 
 
 class DaciteError(Exception):
@@ -46,7 +46,6 @@ class Config:
 
 T = TypeVar('T')
 Data = Dict[str, Any]
-FieldInfo = Dict[str, Field]
 
 
 def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) -> T:
@@ -100,7 +99,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
         else:
             post_init_values[field.name] = value
 
-    return _load_class(data_class, init_values, post_init_values)
+    return _create_instance(data_class, init_values, post_init_values)
 
 
 def _validate_config(data_class: Type[T], data: Data, config: Config):
@@ -333,10 +332,9 @@ def _get_type_name(t: Type) -> str:
     return t.__name__ if hasattr(t, '__name__') else str(t)
 
 
-def _load_class(data_class: Type[T], init_values: Data, post_init_values: Data) -> T:
+def _create_instance(data_class: Type[T], init_values: Data, post_init_values: Data) -> T:
     """loads data into a new dataclass instance"""
     new = data_class(**init_values)
     for key, value in post_init_values.items():
-        # have to go through object here to get around frozen dataclasses
-        object.__setattr__(new, key, value)
+        setattr(new, key, value)
     return new

--- a/tests.py
+++ b/tests.py
@@ -707,3 +707,18 @@ def test_from_dict_with_post_init():
     result = from_dict(X, data)
 
     assert result == answer
+
+
+def test_from_dict_with_already_created_data_class_instances():
+    @dataclass
+    class X:
+        i: int
+
+    @dataclass
+    class Y:
+        x: X
+        x_list: List[X]
+
+    result = from_dict(Y, {'x': X(37), 'x_list': [X(i=42)]})
+
+    assert result == Y(x=X(i=37), x_list=[X(i=42)])

--- a/tests.py
+++ b/tests.py
@@ -690,11 +690,10 @@ def test_from_dict_with_union_and_dict_of_data_classes():
     result = from_dict(Y, {'d': {'x': {'i': 42}, 'z': {'i': 37}}})
 
     assert result == Y(d={'x': X(i=42), 'z': X(i=37)})
+    
 
-
-@pytest.mark.parametrize("frozen", [False, True])
-def test_from_dict_with_post_init(frozen):
-    @dataclass(frozen=frozen)
+def test_from_dict_with_post_init():
+    @dataclass
     class X:
         post: str = field(init=False)
 

--- a/tests.py
+++ b/tests.py
@@ -690,3 +690,21 @@ def test_from_dict_with_union_and_dict_of_data_classes():
     result = from_dict(Y, {'d': {'x': {'i': 42}, 'z': {'i': 37}}})
 
     assert result == Y(d={'x': X(i=42), 'z': X(i=37)})
+
+
+@pytest.mark.parametrize("frozen", [False, True])
+def test_from_dict_with_post_init(frozen):
+    @dataclass(frozen=frozen)
+    class X:
+        post: str = field(init=False)
+
+    data = {
+        "post": "gotcha!"
+    }
+
+    answer = X()
+    object.__setattr__(answer, "post", "gotcha!")
+
+    result = from_dict(X, data)
+
+    assert result == answer


### PR DESCRIPTION
Allows creation of dataclass when non-init data fields exist. These fields are updated after a new instance is created.

This solution also allows for non-init fields to have initial data set even if the dataclass is frozen.

closes: https://github.com/konradhalas/dacite/issues/13