### PR TITLE
Non-dict objects in collection with dataclasses no longer throw an error

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,14 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="dataclasses" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/tests.py
+++ b/tests.py
@@ -690,3 +690,20 @@ def test_from_dict_with_union_and_dict_of_data_classes():
     result = from_dict(Y, {'d': {'x': {'i': 42}, 'z': {'i': 37}}})
 
     assert result == Y(d={'x': X(i=42), 'z': X(i=37)})
+
+
+def test_from_dict_collection_loaded_items():
+    @dataclass
+    class X:
+        text: str = "default"
+
+    @dataclass
+    class Y:
+        x: X = X()
+
+    @dataclass
+    class Y:
+        x_list: List[X] = field(default_factory=list)
+
+    y_dict = {"x_list": [X(), X()]}
+    assert from_dict(Y, y_dict) == Y([X(), X()])


### PR DESCRIPTION
Fixes https://github.com/konradhalas/dacite/issues/16

Right now any non-dict objects are passed when loading items for a collection. This may or may not be desire-able. It allows more lenient unions, but may fail some of the type-checking goals of the lib.

It also means dicts OTHER than dict representations of a dataclass in a collection will not be passed.
This COULD be an issue if you had a collection of both lists and dataclasses.

These are both edge-cases and can likely be safely ignored until someone needs them implemented.