### PR TITLE
Made UnionMatchError a subtype of WrongTypeError

### DIFF
--- a/dacite.py
+++ b/dacite.py
@@ -250,7 +250,7 @@ def _inner_from_dict_for_union(data: Any, field: Field, outer_config: Config) ->
                 return data
         except DaciteError:
             pass
-    raise UnionMatchError(field)
+    raise UnionMatchError(field, data)
 
 
 def _extract_flattened_fields(field: Field, data: Dict[str, Any], remap: Dict[str, str]):

--- a/dacite.py
+++ b/dacite.py
@@ -21,9 +21,7 @@ class MissingValueError(DaciteError):
 
 
 class UnionMatchError(WrongTypeError):
-    def __init__(self, field: Field) -> None:
-        super().__init__(f'can not match the data to any type of "{field.name}" union: {_get_type_name(field.type)}')
-        self.field = field
+    pass
 
 
 class InvalidConfigurationError(DaciteError):

--- a/dacite.py
+++ b/dacite.py
@@ -20,7 +20,7 @@ class MissingValueError(DaciteError):
         self.field = field
 
 
-class UnionMatchError(DaciteError):
+class UnionMatchError(WrongTypeError):
     def __init__(self, field: Field) -> None:
         super().__init__(f'can not match the data to any type of "{field.name}" union: {_get_type_name(field.type)}')
         self.field = field


### PR DESCRIPTION
`UnionMatchError` is a subtype of `WrongTypeError` specialized for `Union`s. There's a chance this could break stuff if people don't expect to catch it when catching `WrongTypeError`, but it's unlikely to break anything too much (if at all).