### PR TITLE
Ability to disable type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 *.egg-info/
 build/
+.idea/

--- a/dacite.py
+++ b/dacite.py
@@ -47,9 +47,8 @@ class Config:
     cast: List[str] = dc_field(default_factory=list)
     transform: Dict[str, Callable[[Any], Any]] = dc_field(default_factory=dict)
     flattened: List[str] = dc_field(default_factory=list)
-    disable_type_validation
-    validate_types: bool = True
     forward_references: Optional[Dict[str, Any]] = None
+    validate_types: bool = True
 
 
 T = TypeVar('T')
@@ -264,10 +263,12 @@ def _inner_from_dict_for_union(data: Any, field: Field, outer_config: Config) ->
                     outer_config=outer_config,
                     field=field,
                 )
-            elif _is_instance(t, data) or not outer_config.validate_types:
+            elif _is_instance(t, data):
                 return data
         except DaciteError:
             pass
+    if not outer_config.validate_types:
+        return data
     raise UnionMatchError(field)
 
 

--- a/dacite.py
+++ b/dacite.py
@@ -42,6 +42,7 @@ class Config:
     cast: List[str] = dc_field(default_factory=list)
     transform: Dict[str, Callable[[Any], Any]] = dc_field(default_factory=dict)
     flattened: List[str] = dc_field(default_factory=list)
+    validate_type: bool = True
 
 
 T = TypeVar('T')
@@ -59,6 +60,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     config = config or Config()
     init_values: Data = {}
     post_init_values: Data = {}
+
     _validate_config(data_class, data, config)
     for field in fields(data_class):
         value, is_default = _get_value_for_field(field, data, config)
@@ -88,7 +90,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
                     )
                 if field.name in config.cast:
                     value = _cast_value(field.type, value)
-            if not _is_instance(field.type, value):
+            if config.validate_type and not _is_instance(field.type, value):
                 raise WrongTypeError(field, value)
         if field.init:
             init_values[field.name] = value
@@ -194,6 +196,7 @@ def _make_inner_config(field: Field, config: Config) -> Config:
         cast=_extract_nested_list(field, config.cast),
         transform=_extract_nested_dict(field, config.transform),
         flattened=_extract_nested_list(field, config.flattened),
+        validate=config.validate_type
     )
 
 
@@ -248,7 +251,7 @@ def _inner_from_dict_for_union(data: Any, field: Field, outer_config: Config) ->
                     outer_config=outer_config,
                     field=field,
                 )
-            elif _is_instance(t, data):
+            elif _is_instance(t, data) or not outer_config.validate_type:
                 return data
         except DaciteError:
             pass

--- a/dacite.py
+++ b/dacite.py
@@ -66,7 +66,6 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     config = config or Config()
     init_values: Data = {}
     post_init_values: Data = {}
-
     _validate_config(data_class, data, config)
     try:
         data_class_hints = get_type_hints(data_class, globalns=config.forward_references)

--- a/dacite.py
+++ b/dacite.py
@@ -42,7 +42,7 @@ class Config:
     cast: List[str] = dc_field(default_factory=list)
     transform: Dict[str, Callable[[Any], Any]] = dc_field(default_factory=dict)
     flattened: List[str] = dc_field(default_factory=list)
-    validate_type: bool = True
+    validate_types: bool = True
 
 
 T = TypeVar('T')
@@ -90,7 +90,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
                     )
                 if field.name in config.cast:
                     value = _cast_value(field.type, value)
-            if config.validate_type and not _is_instance(field.type, value):
+            if config.validate_types and not _is_instance(field.type, value):
                 raise WrongTypeError(field, value)
         if field.init:
             init_values[field.name] = value
@@ -196,7 +196,7 @@ def _make_inner_config(field: Field, config: Config) -> Config:
         cast=_extract_nested_list(field, config.cast),
         transform=_extract_nested_dict(field, config.transform),
         flattened=_extract_nested_list(field, config.flattened),
-        validate=config.validate_type
+        validate_types=config.validate_types
     )
 
 
@@ -251,7 +251,7 @@ def _inner_from_dict_for_union(data: Any, field: Field, outer_config: Config) ->
                     outer_config=outer_config,
                     field=field,
                 )
-            elif _is_instance(t, data) or not outer_config.validate_type:
+            elif _is_instance(t, data) or not outer_config.validate_types:
                 return data
         except DaciteError:
             pass

--- a/tests.py
+++ b/tests.py
@@ -893,7 +893,7 @@ def test_validation_false_passes():
     class X:
         s: int
 
-    result = from_dict(X, {'s': 'text'}, config=Config(validate=False))
+    result = from_dict(X, {'s': 'text'}, config=Config(validate_types=False))
     assert result == X("text")
 
 
@@ -903,7 +903,7 @@ def test_validation_false_missing_data_raises():
         s: int
 
     with pytest.raises(MissingValueError):
-        from_dict(X, dict(), config=Config(validate=False))
+        from_dict(X, dict(), config=Config(validate_types=False))
 
 
 def test_validation_false_passes_union():
@@ -911,7 +911,7 @@ def test_validation_false_passes_union():
     class X:
         s: Union[int, float]
 
-    result = from_dict(X, {'s': "text"}, config=Config(validate=False))
+    result = from_dict(X, {'s': "text"}, config=Config(validate_types=False))
     assert result == X("text")
 
 
@@ -925,5 +925,5 @@ def test_validation_false_passes_nested():
     class Y:
         x: X
 
-    result = from_dict(Y, {'x': {'s': 'text1', 't': 'text2'}}, config=Config(validate=False))
+    result = from_dict(Y, {'x': {'s': 'text1', 't': 'text2'}}, config=Config(validate_types=False))
     assert result == Y(X('text1', 'text2'))

--- a/tests.py
+++ b/tests.py
@@ -886,3 +886,44 @@ def test_from_dict_with_post_init():
     result = from_dict(X, {'s': 'test'})
 
     assert result == x
+
+
+def test_validation_false_passes():
+    @dataclass
+    class X:
+        s: int
+
+    result = from_dict(X, {'s': 'text'}, config=Config(validate=False))
+    assert result == X("text")
+
+
+def test_validation_false_missing_data_raises():
+    @dataclass
+    class X:
+        s: int
+
+    with pytest.raises(MissingValueError):
+        from_dict(X, dict(), config=Config(validate=False))
+
+
+def test_validation_false_passes_union():
+    @dataclass
+    class X:
+        s: Union[int, float]
+
+    result = from_dict(X, {'s': "text"}, config=Config(validate=False))
+    assert result == X("text")
+
+
+def test_validation_false_passes_nested():
+    @dataclass
+    class X:
+        s: int
+        t: Union[int, float]
+
+    @dataclass
+    class Y:
+        x: X
+
+    result = from_dict(Y, {'x': {'s': 'text1', 't': 'text2'}}, config=Config(validate=False))
+    assert result == Y(X('text1', 'text2'))

--- a/tests.py
+++ b/tests.py
@@ -898,48 +898,6 @@ def test_from_dict_with_post_init():
     assert result == x
 
 
-
-def test_validation_false_passes():
-    @dataclass
-    class X:
-        s: int
-
-    result = from_dict(X, {'s': 'text'}, config=Config(validate_types=False))
-    assert result == X("text")
-
-
-def test_validation_false_missing_data_raises():
-    @dataclass
-    class X:
-        s: int
-
-    with pytest.raises(MissingValueError):
-        from_dict(X, dict(), config=Config(validate_types=False))
-
-
-def test_validation_false_passes_union():
-    @dataclass
-    class X:
-        s: Union[int, float]
-
-    result = from_dict(X, {'s': "text"}, config=Config(validate_types=False))
-    assert result == X("text")
-
-
-def test_validation_false_passes_nested():
-    @dataclass
-    class X:
-        s: int
-        t: Union[int, float]
-
-    @dataclass
-    class Y:
-        x: X
-
-    result = from_dict(Y, {'x': {'s': 'text1', 't': 'text2'}}, config=Config(validate_types=False))
-    assert result == Y(X('text1', 'text2'))
-
-
 def test_forward_reference():
 
     @dataclass
@@ -1008,3 +966,45 @@ def test_forward_reference_error():
 
     with pytest.raises(ForwardReferenceError):
         from_dict(X, {"y": {"s": "text"}})
+
+
+def test_validation_false_passes():
+    @dataclass
+    class X:
+        s: int
+
+    result = from_dict(X, {'s': 'text'}, config=Config(validate_types=False))
+    assert result == X("text")
+
+
+def test_validation_false_missing_data_raises():
+    @dataclass
+    class X:
+        s: int
+
+    with pytest.raises(MissingValueError):
+        from_dict(X, dict(), config=Config(validate_types=False))
+
+
+def test_validation_false_passes_union():
+    @dataclass
+    class X:
+        s: Union[int, float]
+
+    result = from_dict(X, {'s': "text"}, config=Config(validate_types=False))
+    assert result == X("text")
+
+
+def test_validation_false_passes_nested():
+    @dataclass
+    class X:
+        s: int
+        t: Union[int, float]
+
+    @dataclass
+    class Y:
+        x: X
+
+    result = from_dict(Y, {'x': {'s': 'text1', 't': 'text2'}}, config=Config(validate_types=False))
+    assert result == Y(X('text1', 'text2'))
+


### PR DESCRIPTION
Hello!

In my workflow I am using dacite in conjunction with [Marshmallow](https://marshmallow.readthedocs.io/en/3.0/index.html). They way my project is set up has Marshmallow running checks on a dict against a schema before the dict is loaded, meaning the dict has been type-checked ahead of time.

It would be nice to disable dacite from running redundant type checks in this case, so I put together a pull request adding this feature. Let me know what you think, and thanks as always.

It adds an optional flag to the config class which allows the ability to disable type checks.