### PR TITLE
Add Ability to use forward references

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@ import pytest
 from dataclasses import dataclass, field
 from typing import Optional, List, Set, Union, Any, Dict
 
-from dacite import from_dict, Config, WrongTypeError, MissingValueError, InvalidConfigurationError, UnionMatchError
+from dacite import from_dict, Config, WrongTypeError, MissingValueError, InvalidConfigurationError, UnionMatchError, ForwardRefError
 
 
 def test_from_dict_from_correct_data():
@@ -886,3 +886,73 @@ def test_from_dict_with_post_init():
     result = from_dict(X, {'s': 'test'})
 
     assert result == x
+
+
+def test_forward_reference():
+
+    @dataclass
+    class X:
+        y: "Y"
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": {"s": "text"}}, Config(forward_refs={"Y": Y}))
+    assert data == X(Y("text"))
+
+
+def test_forward_reference_in_union():
+
+    @dataclass
+    class X:
+        y: Union["Y", str]
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": {"s": "text"}}, Config(forward_refs={"Y": Y}))
+    assert data == X(Y("text"))
+
+
+def test_forward_reference_in_list():
+
+    @dataclass
+    class X:
+        y: List["Y"]
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": [{"s": "text"}]}, Config(forward_refs={"Y": Y}))
+    assert data == X([Y("text")])
+
+
+def test_forward_reference_in_dict():
+
+    @dataclass
+    class X:
+        y: Dict[str, "Y"]
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": {"key": {"s": "text"}}}, Config(forward_refs={"Y": Y}))
+    assert data == X({"key": Y("text")})
+
+
+def test_forward_reference_error():
+
+    @dataclass
+    class X:
+        y: "Y"
+
+    @dataclass
+    class Y:
+        s: str
+
+    with pytest.raises(ForwardRefError):
+        from_dict(X, {"y": {"s": "text"}})


### PR DESCRIPTION
Here is an attempt to add an ability to add forward reference support to dacite.

Rather than have dacite try and deduce forward references itself, this PR adds a config option which can be passed a dictionary of forward references, so decoding of them could be done as so:

```
@dataclass
class X:
    y: "Y"

@dataclass
class Y:
    s: str

data = from_dict(X, {"y": {"s": "text"}}, Config(forward_refs={"Y": Y}))
assert data == X(Y("text"))
```

The current implementation requires passing this expanded config to most of the unpacking and type checking functions in dacite, so that `_get_forward_ref_type` can be run on each type before operation to resolve any possible forward refs.

This is a little bit of a hammer approach, but it gets the job done. Let me know what you think.

Closes: https://github.com/konradhalas/dacite/issues/15