### PR TITLE
Handle Forward References

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Dacite supports following features:
 - (basic) types checking
 - optional fields (i.e. `typing.Optional`)
 - unions
+- forward references
 - collections
 - values casting and transformation
 - remapping of fields names
@@ -96,6 +97,7 @@ Configuration is a (data) class with following fields:
 - `prefixed`
 - `cast`
 - `transform`
+- `forward references`
 
 The examples below show all features of `from_dict` function and usage
 of all `Config` parameters.
@@ -221,6 +223,25 @@ data = {
 result = from_dict(data_class=B, data=data)
 
 assert result == B(a_list=[A(x='test1', y=1), A(x='test2', y=2)])
+```
+
+### Forward References
+
+Definition of forward references can be passed as a `{'name': Type}` mapping to 
+`Config.forward_references`. This dict is passed to `typing.get_type_hints()` as the 
+`globalns` param when evaluating each field's type.
+
+```python
+@dataclass
+class X:
+    y: "Y"
+
+@dataclass
+class Y:
+    s: str
+
+data = from_dict(X, {"y": {"s": "text"}}, Config(forward_references={"Y": Y}))
+assert data == X(Y("text"))
 ```
 
 ### Remapping

--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ required field
 (a field name or a input data key) for a configuration
 - `UnionMatchError` - raised when provided data does not match any type
 of `Union`
+- `ForwardReferenceError` - raised when undefined forward reference encountered in
+dataclass
 
 ## Authors
 

--- a/dacite.py
+++ b/dacite.py
@@ -68,8 +68,8 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     _validate_config(data_class, data, config)
     try:
         data_class_hints = get_type_hints(data_class, globalns=config.forward_references)
-    except NameError:
-        raise ForwardReferenceError
+    except NameError as error:
+        raise ForwardReferenceError(str(error))
     for field in fields(data_class):
         field = copy.copy(field)
         field.type = data_class_hints[field.name]

--- a/dacite.py
+++ b/dacite.py
@@ -36,7 +36,7 @@ class InvalidConfigurationError(DaciteError):
         self.value = value
 
 
-class ForwardReferenceError(DaciteError, TypeError):
+class ForwardReferenceError(DaciteError):
     pass
 
 

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@ import pytest
 from dataclasses import dataclass, field
 from typing import Optional, List, Set, Union, Any, Dict
 
-from dacite import from_dict, Config, WrongTypeError, MissingValueError, InvalidConfigurationError, UnionMatchError
+from dacite import from_dict, Config, WrongTypeError, MissingValueError, InvalidConfigurationError, UnionMatchError, ForwardReferenceError
 
 
 def test_from_dict_from_correct_data():
@@ -886,3 +886,73 @@ def test_from_dict_with_post_init():
     result = from_dict(X, {'s': 'test'})
 
     assert result == x
+
+
+def test_forward_reference():
+
+    @dataclass
+    class X:
+        y: "Y"
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": {"s": "text"}})
+    assert data == X(Y("text"))
+
+
+def test_forward_reference_in_union():
+
+    @dataclass
+    class X:
+        y: Union["Y", str]
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": {"s": "text"}})
+    assert data == X(Y("text"))
+
+
+def test_forward_reference_in_list():
+
+    @dataclass
+    class X:
+        y: List["Y"]
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": [{"s": "text"}]})
+    assert data == X([Y("text")])
+
+
+def test_forward_reference_in_dict():
+
+    @dataclass
+    class X:
+        y: Dict[str, "Y"]
+
+    @dataclass
+    class Y:
+        s: str
+
+    data = from_dict(X, {"y": {"key": {"s": "text"}}})
+    assert data == X({"key": Y("text")})
+
+
+def test_forward_reference_error():
+
+    @dataclass
+    class X:
+        y: "Y"
+
+    @dataclass
+    class Y:
+        s: str
+
+    with pytest.raises(ForwardReferenceError):
+        from_dict(X, {"y": {"s": "text"}})

--- a/tests.py
+++ b/tests.py
@@ -898,7 +898,7 @@ def test_forward_reference():
     class Y:
         s: str
 
-    data = from_dict(X, {"y": {"s": "text"}})
+    data = from_dict(X, {"y": {"s": "text"}}, Config(forward_references={"Y": Y}))
     assert data == X(Y("text"))
 
 
@@ -912,7 +912,7 @@ def test_forward_reference_in_union():
     class Y:
         s: str
 
-    data = from_dict(X, {"y": {"s": "text"}})
+    data = from_dict(X, {"y": {"s": "text"}}, Config(forward_references={"Y": Y}))
     assert data == X(Y("text"))
 
 
@@ -926,7 +926,7 @@ def test_forward_reference_in_list():
     class Y:
         s: str
 
-    data = from_dict(X, {"y": [{"s": "text"}]})
+    data = from_dict(X, {"y": [{"s": "text"}]}, Config(forward_references={"Y": Y}))
     assert data == X([Y("text")])
 
 
@@ -940,7 +940,7 @@ def test_forward_reference_in_dict():
     class Y:
         s: str
 
-    data = from_dict(X, {"y": {"key": {"s": "text"}}})
+    data = from_dict(X, {"y": {"key": {"s": "text"}}}, Config(forward_references={"Y": Y}))
     assert data == X({"key": Y("text")})
 
 


### PR DESCRIPTION
New attempt to close issue https://github.com/konradhalas/dacite/issues/15
Last attempt: https://github.com/konradhalas/dacite/pull/25

This version is significantly less invasive. It still relies on passing a dict of forward references to the Config class, these are then passed to the `globalns` param of `typing.get_type_hints()`, cleaning each type hint of forward refs.

The resolved types are injected into the rest of the code by creating a copy of each `dataclass.Field` object in the main loop, and reassigning the `.type` attr to the cleaned type. 

Each new field object then carries forward the correct type to the rest of the logic.

Let me know what you think!