### PR TITLE
Add support for python enum.Enum

### DIFF
--- a/dacite.py
+++ b/dacite.py
@@ -1,3 +1,5 @@
+import inspect
+import enum
 from dataclasses import fields, MISSING, is_dataclass, Field, dataclass, field as dc_field
 from typing import Dict, Any, TypeVar, Type, Union, Callable, List, Collection, Optional, Set, Mapping, Tuple
 
@@ -88,8 +90,14 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
                     )
                 if field.name in config.cast:
                     value = _cast_value(field.type, value)
-            if not _is_instance(field.type, value):
+
+            # do not raise WrongTypeError when its enum
+            # e.g. it can be enum of ints, but type is MyEnum
+            if inspect.isclass(field.type) and issubclass(field.type, enum.Enum):
+                value = field.type(value)
+            elif not _is_instance(field.type, value):
                 raise WrongTypeError(field, value)
+
         if field.init:
             init_values[field.name] = value
         else:

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import enum
 import pytest
 from dataclasses import dataclass, field
 from typing import Optional, List, Set, Union, Any, Dict
@@ -884,5 +885,39 @@ def test_from_dict_with_post_init():
     x.s = 'test'
 
     result = from_dict(X, {'s': 'test'})
+
+    assert result == x
+
+
+def test_from_dict_with_enum():
+    class MyEnum(enum.Enum):
+        a: int = 1
+        b: int = 3
+
+    @dataclass
+    class X:
+        e: MyEnum = MyEnum.a
+
+    x = X()
+
+    result = from_dict(X, {"e": 1})
+
+    assert result == x
+
+
+def test_from_dict_with_enum_multiple_inheritance():
+    class StrEnum(str, enum.Enum):
+        pass
+
+    class YEnum(StrEnum):
+        b: str = "hello"
+
+    @dataclass
+    class X:
+        e: YEnum = YEnum.b
+
+    x = X()
+    
+    result = from_dict(X, {"e": "hello"})
 
     assert result == x


### PR DESCRIPTION
Do not raise WrongTypeError when value is of type Enum. 
E.g. it can be Enum of ints, so first try to convert the value of int to Enum type.

For further details see tests.