### PR TITLE
Fix optional union with "None" value

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -78,8 +78,8 @@ def _build_value(type_: Type, data: Any, config: Config) -> Any:
 
 
 def _build_value_for_union(union: Type, data: Any, config: Config) -> Any:
-    types = [type_ for type_ in extract_generic(union) if type_ is not type(None)]
-    if is_optional(union) and len(extract_generic(union)) == 2:
+    types = extract_generic(union)
+    if is_optional(union) and len(types) == 2:
         return _build_value(type_=types[0], data=data, config=config)
     for inner_type in types:
         try:

--- a/tests/core/test_optional.py
+++ b/tests/core/test_optional.py
@@ -38,6 +38,16 @@ def test_from_dict_with_missing_optional_value_for_union():
     assert result == X(i=None)
 
 
+def test_from_dict_with_none_optional_value_for_union():
+    @dataclass
+    class X:
+        i: Optional[Union[int, str]]
+
+    result = from_dict(X, {"i": None})
+
+    assert result == X(i=None)
+
+
 def test_from_dict_with_none_as_optional_value():
     @dataclass
     class X:

--- a/tests/core/test_union.py
+++ b/tests/core/test_union.py
@@ -106,6 +106,15 @@ def test_from_dict_with_union_and_optional_and_missing_value():
     assert result == X(i=None)
 
 
+def test_from_dict_with_union_and_optional_and_none_value():
+    @dataclass
+    class X:
+        i: Union[int, Optional[str]]
+
+    result = from_dict(X, {"i": None})
+    assert result == X(i=None)
+
+
 def test_from_dict_with_union_and_optional_and_wrong_value():
     @dataclass
     class X:


### PR DESCRIPTION
Currently, dacit correctly handles `None` value when a field has a type of `Optional[Type]` (which is expanded to `Union[Type, NoneType]`) by checking that union is optional and has two types: 
https://github.com/konradhalas/dacite/blob/ece070cc3c25e86634086db8ee4f2e45bdfe6fe5/dacite/core.py#L82
  
But when a field has a type of `Optional[Union[Type, Type]]` or `Union[Type, Optional[Type]]` (which will expand to `Union[Type, Type, NoneType]` in both cases), dacite raises `UnionMatchError` if value is `None`:
```python
dacite.exceptions.UnionMatchError: can not match type "NoneType" to any type of "i" union: typing.Union[int, str, NoneType]
```
  
The reason for this error is that `NoneType` is removed from the list of checked types:
https://github.com/konradhalas/dacite/blob/ece070cc3c25e86634086db8ee4f2e45bdfe6fe5/dacite/core.py#L81
I'm not sure what this check is for, but without it everything should work fine (at least all tests are green).
  
Added tests for specified cases