### PR TITLE
removed dataclasses dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,9 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 7):
-    requirements = ["dataclasses"]
-else:
-    requirements = []
-
 setup(
     name="dacite",
-    version="0.0.25",
+    version="0.0.26",
     description="Simple creation of data classes from dictionaries.",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -30,6 +25,6 @@ setup(
     python_requires=">=3.6",
     keywords="dataclasses",
     packages=["dacite"],
-    install_requires=requirements,
+    install_requires=[],
     extras_require={"dev": ["pytest>=4", "pytest-cov", "coveralls", "black", "mypy", "pylint"]},
 )


### PR DESCRIPTION
Dacite is requiring dataclasses a dependency. Dataclasses is a root python module and is included with python. Using version `0.0.25` may result in including a version of dataclasses that is incompatible with the most recent version of the typings module.

```
if sys.version_info < (3, 7):
    requirements = ["dataclasses"]
else:
    requirements = []
```

The python version check here was meant to only include dataclasses if the python version was `<3.7.0`. But doing this version check in pip is unreliable, and results in including the dataclasses package even when using python `>=3.7.0`.

Attempts to use `python3.7 -m pip` does not work.

These lines should be removed. Anyone using python `<3.7.0` must pin to an older version of dacite or upgrade.