### PR TITLE
WIP: Add support for user generic types

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,6 +1,6 @@
 import copy
 from dataclasses import fields, is_dataclass
-from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any
+from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Generic, Tuple
 
 from dacite.config import Config
 from dacite.data import Data
@@ -22,27 +22,40 @@ from dacite.types import (
     extract_generic,
     is_optional,
     transform_value,
+    is_generic,
+    extract_metaclass,
 )
 
 T = TypeVar("T")
 
+def _substitute_types(type_: Generic[T], type_mapping: Mapping[Type, Type]) -> Tuple[Type, Type]:
+    mapped = tuple(
+        (type_mapping[t] if t in type_mapping else t for t in type_.__args__))
+    metatype = extract_metaclass(type_)
+    return metatype[mapped], metatype
 
-def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) -> T:
-    """Create a data class instance from a dictionary.
 
-    :param data_class: a data class type
-    :param data: a dictionary of a input data
-    :param config: a configuration of the creation process
-    :return: an instance of a data class
-    """
+def _from_dict(data_class: Type[T], data: Data, config: Config,
+               type_mapping: Mapping[Type, Type]) -> T:
+
     init_values: Data = {}
     post_init_values: Data = {}
-    config = config or Config()
+
+    if is_generic(data_class):
+        data_metaclass = extract_origin_collection(data_class)
+        local_mapping = {
+            generic: type_mapping[param] if param in type_mapping else param
+            for generic, param in zip(data_metaclass.__parameters__, extract_generic(data_class))
+        }
+    else:
+        data_metaclass = data_class
+        local_mapping = {}
+
     try:
-        data_class_hints = get_type_hints(data_class, globalns=config.forward_references)
+        data_class_hints = get_type_hints(data_metaclass, globalns=config.forward_references)
     except NameError as error:
         raise ForwardReferenceError(str(error))
-    data_class_fields = fields(data_class)
+    data_class_fields = fields(data_metaclass)
     if config.strict:
         extra_fields = set(data.keys()) - {f.name for f in data_class_fields}
         if extra_fields:
@@ -50,17 +63,28 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     for field in data_class_fields:
         field = copy.copy(field)
         field.type = data_class_hints[field.name]
+        if field.type in local_mapping:
+            field.type = local_mapping[field.type]
+
+        if is_generic(field.type) and not is_union(field.type):
+            field.type, field_metatype = _substitute_types(field.type, type_mapping)
+        else:
+            field_metatype = field.type
+
         try:
             try:
                 field_data = data[field.name]
-                transformed_value = transform_value(
-                    type_hooks=config.type_hooks, target_type=field.type, value=field_data
-                )
-                value = _build_value(type_=field.type, data=transformed_value, config=config)
+                transformed_value = transform_value(type_hooks=config.type_hooks,
+                                                    target_type=field.type,
+                                                    value=field_data)
+                value = _build_value(type_=field.type,
+                                     data=transformed_value,
+                                     config=config,
+                                     type_mapping=type_mapping)
             except DaciteFieldError as error:
                 error.update_path(field.name)
                 raise
-            if config.check_types and not is_instance(value, field.type):
+            if config.check_types and not is_instance(value, field_metatype):
                 raise WrongTypeError(field_path=field.name, field_type=field.type, value=value)
         except KeyError:
             try:
@@ -74,27 +98,47 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
         else:
             post_init_values[field.name] = value
 
-    return create_instance(data_class=data_class, init_values=init_values, post_init_values=post_init_values)
+    return create_instance(data_class=data_class,
+                           init_values=init_values,
+                           post_init_values=post_init_values)
 
 
-def _build_value(type_: Type, data: Any, config: Config) -> Any:
+def _build_value(type_: Type, data: Any, config: Config, type_mapping: Mapping[Type, Type]) -> Any:
     if is_union(type_):
-        return _build_value_for_union(union=type_, data=data, config=config)
+        return _build_value_for_union(union=type_,
+                                      data=data,
+                                      config=config,
+                                      type_mapping=type_mapping)
     elif is_generic_collection(type_) and is_instance(data, type_):
-        return _build_value_for_collection(collection=type_, data=data, config=config)
-    elif is_dataclass(type_) and is_instance(data, Data):
-        return from_dict(data_class=type_, data=data, config=config)
+        return _build_value_for_collection(collection=type_,
+                                           data=data,
+                                           config=config,
+                                           type_mapping=type_mapping)
+    elif (is_dataclass(type_) or
+          (is_generic(type_) and is_dataclass(extract_origin_collection(type_)))) and is_instance(
+              data, Data):
+        return _from_dict(data_class=type_, data=data, config=config, type_mapping=type_mapping)
+
     return data
 
 
-def _build_value_for_union(union: Type, data: Any, config: Config) -> Any:
+def _build_value_for_union(union: Type, data: Any, config: Config,
+                           type_mapping: Mapping[Type, Type]) -> Any:
     types = extract_generic(union)
     if is_optional(union) and len(types) == 2:
-        return _build_value(type_=types[0], data=data, config=config)
+        return _build_value(type_=types[0], data=data, config=config, type_mapping=type_mapping)
     for inner_type in types:
         try:
-            value = _build_value(type_=inner_type, data=data, config=config)
-            if is_instance(value, inner_type):
+            if is_generic(inner_type):
+                inner_type, metatype = _substitute_types(inner_type, type_mapping)
+            else:
+                metatype = inner_type
+
+            value = _build_value(type_=inner_type,
+                                 data=data,
+                                 config=config,
+                                 type_mapping=type_mapping)
+            if is_instance(value, metatype):
                 return value
         except DaciteError:
             pass
@@ -103,11 +147,40 @@ def _build_value_for_union(union: Type, data: Any, config: Config) -> Any:
     raise UnionMatchError(field_type=union, value=data)
 
 
-def _build_value_for_collection(collection: Type, data: Any, config: Config) -> Any:
+def _build_value_for_collection(collection: Type, data: Any, config: Config,
+                                type_mapping: Mapping[Type, Type]) -> Any:
     collection_cls = extract_origin_collection(collection)
     if is_instance(data, Mapping):
-        return collection_cls(
-            (key, _build_value(type_=extract_generic(collection)[1], data=value, config=config))
-            for key, value in data.items()
-        )
-    return collection_cls(_build_value(type_=extract_generic(collection)[0], data=item, config=config) for item in data)
+        return collection_cls((key,
+                               _build_value(type_=extract_generic(collection)[1],
+                                            data=value,
+                                            config=config,
+                                            type_mapping=type_mapping))
+                              for key, value in data.items())
+    return collection_cls(
+        _build_value(type_=extract_generic(collection)[0],
+                     data=item,
+                     config=config,
+                     type_mapping=type_mapping) for item in data)
+
+
+def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) -> T:
+    """Create a data class instance from a dictionary.
+
+    :param data_class: a data class type
+    :param data: a dictionary of a input data
+    :param config: a configuration of the creation process
+    :return: an instance of a data class
+    """
+    config = config or Config()
+
+    if is_generic(data_class):
+        origin = extract_origin_collection(data_class)
+        type_mapping = {
+            generic: param
+            for generic, param in zip(origin.__parameters__, extract_generic(data_class))
+        }
+    else:
+        type_mapping = {}
+
+    return _from_dict(data_class=data_class, data=data, config=config, type_mapping=type_mapping)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,290 @@
+from dataclasses import dataclass
+from typing import Generic, TypeVar, List, Union
+import pytest
+from dacite import from_dict, WrongTypeError
+
+T = TypeVar('T')
+
+
+@dataclass()
+class Simple(Generic[T]):
+    value: T
+
+
+def test_simple():
+    parsed = from_dict(data_class=Simple[int], data={
+        'value': 10,
+    })
+    reference = Simple[int](10)
+    assert isinstance(parsed, Simple)
+    assert type(parsed) == type(reference)
+    assert parsed == reference
+
+
+def test_simple_rises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=Simple[float], data={
+            'value': 10,
+        })
+
+
+@dataclass()
+class Nested(Generic[T]):
+    value: Simple[T]
+
+
+def test_nested():
+    parsed = from_dict(data_class=Nested[int], data={'value': {'value': 1}})
+    reference = Nested[int](Simple[int](1))
+    assert isinstance(parsed, Nested)
+    assert isinstance(parsed.value, Simple)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+def test_nested_raises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=Nested[int], data={'value': {'value': 1.2}})
+
+
+U = TypeVar('U')
+
+
+@dataclass()
+class RecursiveSimple(Generic[U]):
+    value: Simple[Simple[U]]
+
+
+def test_recursivesimple():
+    parsed = from_dict(data_class=RecursiveSimple[int],
+                       data={'value': {
+                           'value': {
+                               'value': 1
+                           }
+                       }})
+    reference = RecursiveSimple[int](Simple[Simple[int]](Simple[int](1)))
+    assert isinstance(parsed, RecursiveSimple)
+    assert isinstance(parsed.value, Simple)
+    assert isinstance(parsed.value.value, Simple)
+    assert isinstance(parsed.value.value.value, int)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+def test_recursivesimpleraises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=RecursiveSimple[int],
+                  data={'value': {
+                      'value': {
+                          'value': 1.2
+                      }
+                  }})
+
+
+@dataclass()
+class ListOfInt:
+    value: List[int]
+
+
+def test_listofint():
+    parsed = from_dict(data_class=ListOfInt, data={'value': [1, 2, 3]})
+    reference = ListOfInt([1, 2, 3])
+    assert isinstance(parsed, ListOfInt)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+@dataclass()
+class ListOfListOfInt:
+    value: List[List[int]]
+
+
+def test_listoflistofint():
+    parsed = from_dict(data_class=ListOfListOfInt,
+                       data={'value': [[1, 2, 3], [4, 5, 6]]})
+    reference = ListOfListOfInt([[1, 2, 3], [4, 5, 6]])
+    assert isinstance(parsed, ListOfListOfInt)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+@pytest.mark.skip("Does not work, but never did")
+def test_listoflistofintraises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=ListOfListOfInt,
+                  data={'value': [[1, "2q", 3], [4, 5, 6]]})
+
+
+@dataclass()
+class ListOfSimple(Generic[T]):
+    value: List[Simple[T]]
+
+
+def test_listofsimple():
+    parsed = from_dict(
+        data_class=ListOfSimple[int],
+        data={'value': [
+            {
+                'value': 1
+            },
+            {
+                'value': 2
+            },
+            {
+                'value': 3
+            },
+        ]})
+    reference = ListOfSimple[int](
+        [Simple[int](1), Simple[int](2), Simple[int](3)])
+    assert isinstance(parsed, ListOfSimple)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+@dataclass()
+class Pair(Generic[T, U]):
+    first: T
+    second: U
+
+
+def test_pairparsing():
+    parsed = from_dict(data_class=Pair[int, float],
+                       data={
+                           'first': 1,
+                           'second': 1.2
+                       })
+    reference = Pair[int, float](1, 1.2)
+    assert isinstance(parsed, Pair)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+def test_pairraises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=Pair[int, float],
+                  data={
+                      'first': 1.2,
+                      'second': 11
+                  })
+
+
+@dataclass()
+class PairNested(Generic[T, U]):
+    first: Pair[int, T]
+    second: Pair[U, float]
+
+
+def test_pairnestedparsing():
+    parsed = from_dict(data_class=PairNested[int, float],
+                       data={
+                           'first': {
+                               'first': 1,
+                               'second': 2
+                           },
+                           'second': {
+                               'first': 3.4,
+                               'second': 5.6
+                           }
+                       })
+    reference = PairNested[int, float](Pair[int, int](1, 2),
+                                       Pair[float, float](3.4, 5.6))
+    assert isinstance(parsed, PairNested)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+def test_pairnestedraises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=PairNested[int, float],
+                  data={
+                      'first': {
+                          'first': 1.2,
+                          'second': 2
+                      },
+                      'second': {
+                          'first': 3.4,
+                          'second': 5.6
+                      }
+                  })
+
+
+@dataclass()
+class RecursiveGeneric(Generic[T, U]):
+    value: Pair[Simple[Pair[int, T]], Pair[U, T]]
+
+
+def test_recursivegeneric():
+    parsed = from_dict(data_class=RecursiveGeneric[int, float],
+                       data={
+                           'value': {
+                               'first': {
+                                   'value': {
+                                       'first': 1,
+                                       'second': 2
+                                   }
+                               },
+                               'second': {
+                                   'first': 4.5,
+                                   'second': 6
+                               }
+                           }
+                       })
+    reference = RecursiveGeneric[int, float](
+        Pair[Simple[Pair[int, int]], Pair[float, int]](Simple[Pair[int, int]](
+            Pair[int, int](1, 2)), Pair[float, int](4.5, 6)))
+    assert isinstance(parsed, RecursiveGeneric)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+
+def test_recursivegenericraises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=RecursiveGeneric[int, float],
+                  data={
+                      'value': {
+                          'first': {
+                              'value': {
+                                  'first': 1.2,
+                                  'second': 2
+                              }
+                          },
+                          'second': {
+                              'first': 4.5,
+                              'second': 6
+                          }
+                      }
+                  })
+
+
+@dataclass()
+class UnionOfSimple(Generic[T, U]):
+    value: Union[Simple[T], Simple[U]]
+
+
+def test_unionofsimple():
+    parsed = from_dict(data_class=UnionOfSimple[int, str],
+                       data={'value': {
+                           'value': 12
+                       }})
+    reference = UnionOfSimple[int, str](Simple[int](12))
+    assert isinstance(parsed, UnionOfSimple)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+
+    parsed = from_dict(data_class=UnionOfSimple[int, str],
+                       data={'value': {
+                           'value': "abc"
+                       }})
+    reference = UnionOfSimple[int, str](Simple[str]("abc"))
+    assert isinstance(parsed, UnionOfSimple)
+    assert parsed == reference
+    assert type(parsed) == type(reference)
+    assert type(parsed.value) == type(reference.value)
+
+
+def test_unionofsimple_raises():
+    with pytest.raises(WrongTypeError):
+        from_dict(data_class=UnionOfSimple[int, str],
+                  data={'value': {
+                      'value': 1.23
+                  }})


### PR DESCRIPTION
Addresses issue #30

Only Python 3.7 right now.

Current implementation does not support generic dataclasses created with typing.Generic metaclass
e.g. class Simple(Generic[T])

The code is not polished and more testcases could be still added.
Especially tests for generic Union and Mapping are missing.

