### PR TITLE
Add type information to build (PEP 561)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
     keywords="dataclasses",
     packages=["dacite"],
     package_data={"dacite": ["py.typed"]},
-    include_package_data=True,
     install_requires=['dataclasses;python_version<"3.7"'],
     extras_require={"dev": ["pytest>=4", "pytest-cov", "coveralls", "black", "mypy", "pylint"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
     python_requires=">=3.6",
     keywords="dataclasses",
     packages=["dacite"],
+    package_data={"dacite": ["py.typed"]},
+    include_package_data=True,
     install_requires=['dataclasses;python_version<"3.7"'],
     extras_require={"dev": ["pytest>=4", "pytest-cov", "coveralls", "black", "mypy", "pylint"]},
 )


### PR DESCRIPTION
- ~~Use install_requires semantics to specify that dataclasses should only be installed on < 3.7. Keeping install_requires static helps tools like PyCharm parse it, it will usually refuse to do that if there are dynamically constructed lists.~~

See https://www.python.org/dev/peps/pep-0561/#packaging-type-information about py.typed. Adding this will make mypy use the packages' type hints.