### PR TITLE
Add stricter mypy type check flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 script:
 - pytest --cov=dacite
 - black --check .
-- mypy dacite
+- mypy
 - pylint dacite
 after_success:
   coveralls

--- a/dacite/__init__.py
+++ b/dacite/__init__.py
@@ -1,3 +1,18 @@
 from dacite.config import Config
 from dacite.core import from_dict
-from dacite.exceptions import *
+from dacite.exceptions import (
+    DaciteError, DaciteFieldError, WrongTypeError, MissingValueError,
+    UnionMatchError, ForwardReferenceError, UnexpectedDataError,
+)
+
+__all__ = (
+    'Config',
+    'from_dict',
+    'DaciteError',
+    'DaciteFieldError',
+    'WrongTypeError',
+    'MissingValueError',
+    'UnionMatchError',
+    'ForwardReferenceError',
+    'UnexpectedDataError',
+)

--- a/dacite/dataclasses.py
+++ b/dacite/dataclasses.py
@@ -22,7 +22,7 @@ def get_default_value_for_field(field: Field) -> Any:
 
 
 def create_instance(data_class: Type[T], init_values: Data, post_init_values: Data) -> T:
-    instance = data_class(**init_values)
+    instance: T = data_class(**init_values)
     for key, value in post_init_values.items():
         setattr(instance, key, value)
     return instance

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -125,7 +125,7 @@ def is_generic_collection(type_: Type) -> bool:
 
 
 def extract_generic(type_: Type) -> tuple:
-    return type_.__args__  # type: ignore
+    return type_.__args__
 
 
 def is_subclass(sub_type: Type, base_type: Type) -> bool:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,22 @@
+[mypy]
+python_version = 3.6
+files = dacite
+show_error_codes = True
+pretty = True
+
+no_implicit_reexport = True
+no_implicit_optional = True
+strict_equality = True
+strict_optional = True
+check_untyped_defs = True
+disallow_incomplete_defs = True
+ignore_missing_imports = False
+
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_return_any = True
+warn_unreachable = True
+
+[mypy-dacite.types]
+warn_return_any = False


### PR DESCRIPTION
- Remove unused type: ignore.
- Remove asterisk import and add `__all__` with all exported names, to
  pass with the `no_explicit_reexport` mypy flag.
- Add various mypy config for developer ergonomics (prettier errors,
  printing error codes, warning about unused config, ignores and casts
  etc). Kept `warn_return_any = False` in `dacite.types` for now since there
  would have to be a lot of ignores/casts otherwise.

This is a somewhat opinionated PR. The added `__all__` makes the public API of the package more explicit and enables consumers of the library to type check with `no_explicit_reexport = True` in mypy. Adding  `python_version = 3.6` helps finding incompatibilities, such as trying to import `Literal` from stdlib `typing`, with mypy. dacite already passes with most of the stricter settings except for one found unnecessary ignore (`warn_unused_ignores`) and one added type hint in `dacite.dataclasses.create_instance()`. The exception is the `dacite.types` module where mypy isn't very successful at inferring return types, so I set `warn_return_any = False` for that file.

As I said I consider this opinionated, but do feel free to ask for changes if you're interested in some or all of these changes. 