### PR TITLE
Add Generic Hook Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .pytest_cache/
+.mypy_cache/
 *.pyc
 dist/
 *.egg-info/

--- a/README.md
+++ b/README.md
@@ -257,6 +257,56 @@ If a data class field type is a `Optional[T]` you can pass both -
 collections, e.g. when a field has type `List[T]` you can use `List[T]` to 
 transform whole collection or `T` to transform each item. 
 
+To target all types use `Any`.  Targeting collections without their sub-types
+will target all collections of those types. 
+
+```python
+@dataclass
+class ShoppingCart:
+    store: str
+    item_ids: List[int]
+
+data = {
+    'store': '7-Eleven',
+    'item_ids': [1, 2, 3],
+}
+
+def print_value(value):
+    print(value)
+    return value
+
+def print_collection(collection):
+    for item in collection:
+        print(item)
+    return collection
+
+result = from_dict(
+    data_class=ShoppingCart, 
+    data=data, 
+    config=Config(
+        type_hooks={
+            Any: print_value, 
+            list: print_collection
+        }
+    )
+)
+```
+
+prints
+
+```
+7-Eleven
+[1, 2, 3]
+1
+2
+3
+```
+
+If a data class field type is a `Optional[T]` you can pass both - 
+`Optional[T]` or just `T` - as a key in `type_hooks`. The same with generic 
+collections, e.g. when a field has type `List[T]` you can use `List[T]` to 
+transform whole collection or `T` to transform each item. 
+
 ### Casting
 
 It's a very common case that you want to create an instance of a field type 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ collections, e.g. when a field has type `List[T]` you can use `List[T]` to
 transform whole collection or `T` to transform each item. 
 
 To target all types use `Any`.  Targeting collections without their sub-types
-will target all collections of those types. 
+will target all collections of those types, such as `List` and `Dict`. 
 
 ```python
 @dataclass
@@ -286,7 +286,7 @@ result = from_dict(
     config=Config(
         type_hooks={
             Any: print_value, 
-            list: print_collection
+            List: print_collection
         }
     )
 )

--- a/dacite/config.py
+++ b/dacite/config.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
-from typing import Dict, Any, Callable, Optional, Type, List
+from typing import Dict, Any, Callable, Optional, Type, List, Union
 
 
 @dataclass
 class Config:
-    type_hooks: Dict[Type, Callable[[Any], Any]] = field(default_factory=dict)
+    type_hooks: Dict[Union[Type, object], Callable[[Any], Any]] = field(default_factory=dict)
     cast: List[Type] = field(default_factory=list)
     forward_references: Optional[Dict[str, Any]] = None
     check_types: bool = True

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, List, Union
+from typing import Any, Dict, Optional, List, Union
 
 import pytest
 
@@ -35,6 +35,40 @@ def test_from_dict_with_type_hooks_and_union():
     result = from_dict(X, {"s": "TEST"}, Config(type_hooks={str: str.lower}))
 
     assert result == X(s="test")
+
+
+def test_from_dict_with_generic_type_hooks():
+    @dataclass
+    class X:
+        s: str
+
+    result = from_dict(X, {"s": "TEST"}, Config(type_hooks={Any: str.lower}))
+
+    assert result == X(s="test")
+
+
+def test_from_dict_with_generic_list_type_hooks():
+    @dataclass
+    class X:
+        l: List[int]
+
+    result = from_dict(X, {"l": [3,1,2]}, Config(type_hooks={List: sorted}))
+
+    assert result == X(l=[1,2,3])
+
+
+def test_from_dict_with_generic_dict_type_hooks():
+    @dataclass
+    class X:
+        d: Dict[str, int]
+    
+    def add_b(value):
+        value["b"] = 2
+        return value
+
+    result = from_dict(X, {"d": {"a": 1}}, Config(type_hooks={Dict: add_b}))
+
+    assert result == X(d={"a": 1, "b": 2})
 
 
 def test_from_dict_with_cast():


### PR DESCRIPTION
Added in the ability to hook all of a major type, and added tests/docs.  From the Readme:

To target all types use `Any`.  Targeting collections without their sub-types
will target all collections of those types, such as `List` and `Dict`. 

```python
@dataclass
class ShoppingCart:
    store: str
    item_ids: List[int]

data = {
    'store': '7-Eleven',
    'item_ids': [1, 2, 3],
}

def print_value(value):
    print(value)
    return value

def print_collection(collection):
    for item in collection:
        print(item)
    return collection

result = from_dict(
    data_class=ShoppingCart, 
    data=data, 
    config=Config(
        type_hooks={
            Any: print_value, 
            List: print_collection
        }
    )
)
```

prints

```
7-Eleven
[1, 2, 3]
1
2
3
```