### PR TITLE
Fix encoding of PKG-INFO file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="dacite",
     version="1.4.0",
     description="Simple creation of data classes from dictionaries.",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Konrad Hałas",
     author_email="halas.konrad@gmail.com",


### PR DESCRIPTION
Reproducible build fails if the file is encoded differently depending on the current locale settings when reading README.md.