### PR TITLE
add option to catch ambiguous union resolution

### DIFF
--- a/dacite/config.py
+++ b/dacite/config.py
@@ -9,3 +9,4 @@ class Config:
     forward_references: Optional[Dict[str, Any]] = None
     check_types: bool = True
     strict: bool = False
+    no_ambiguous_resolution: bool = False

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -13,6 +13,7 @@ from dacite.exceptions import (
     MissingValueError,
     DaciteFieldError,
     UnexpectedDataError,
+    AmbiguousResolutionError,
 )
 from dacite.types import (
     is_instance,
@@ -91,15 +92,27 @@ def _build_value_for_union(union: Type, data: Any, config: Config) -> Any:
     types = extract_generic(union)
     if is_optional(union) and len(types) == 2:
         return _build_value(type_=types[0], data=data, config=config)
+    valid_resolutions = {}
     for inner_type in types:
         try:
             value = _build_value(type_=inner_type, data=data, config=config)
             if is_instance(value, inner_type):
-                return transform_value(
-                    type_hooks=config.type_hooks, cast=config.cast, target_type=inner_type, value=value
-                )
+                if config.no_ambiguous_resolution:
+                    valid_resolutions[inner_type] = value
+                else:
+                    return transform_value(
+                        type_hooks=config.type_hooks, cast=config.cast, target_type=inner_type, value=value
+                    )
         except DaciteError:
             pass
+    if config.no_ambiguous_resolution:
+        if len(valid_resolutions) > 1:
+            raise AmbiguousResolutionError(valid_resolutions)
+        else:
+            unique_value = valid_resolutions.popitem()[1]
+            return transform_value(
+                type_hooks=config.type_hooks, cast=config.cast, target_type=inner_type, value=value
+            )
     if not config.check_types:
         return data
     raise UnionMatchError(field_type=union, value=data)

--- a/dacite/exceptions.py
+++ b/dacite/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, Optional, Set
+from typing import Any, Type, Optional, Set, Dict
 
 
 def _name(type_: Type) -> str:
@@ -47,6 +47,18 @@ class UnionMatchError(WrongTypeError):
         return (
             f'can not match type "{_name(type(self.value))}" to any type '
             f'of "{self.field_path}" union: {_name(self.field_type)}'
+        )
+
+class AmbiguousResolutionError(DaciteError):
+    def __init__(self, resolutions: Dict) -> None:
+        super().__init__()
+        self.resolutions = resolutions
+
+    def __str__(self) -> str:
+        conflicting_types = ', '.join(f'{key}' for key in self.resolutions.keys())
+        return (
+            f'cannot choose between possible Union member resolutions:\n'
+            '{}'.format(conflicting_types)
         )
 
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -4,7 +4,13 @@ from typing import Optional, List, Union
 
 import pytest
 
-from dacite import from_dict, Config, ForwardReferenceError, UnexpectedDataError
+from dacite import (
+    from_dict,
+    Config,
+    ForwardReferenceError,
+    UnexpectedDataError,
+    AmbiguousResolutionError,
+)
 
 
 def test_from_dict_with_type_hooks():
@@ -152,3 +158,26 @@ def test_from_dict_with_strict():
         from_dict(X, {"s": "test", "i": 1}, Config(strict=True))
 
     assert str(exception_info.value) == 'can not match "i" to any data class field'
+
+
+def test_no_ambiguous_resolution():
+    @dataclass
+    class X:
+        i: int
+
+    @dataclass
+    class Y:
+        i: int
+
+    @dataclass
+    class Z:
+        u: Union[X, Y]
+
+    data = {
+        'u': {
+            'i': 0,
+        },
+    }
+
+    with pytest.raises(AmbiguousResolutionError):
+        result = from_dict(data_class=Z, data=data, config=Config(no_ambiguous_resolution=True))


### PR DESCRIPTION
Hi. I'm not sure if this feature is desired in dacite, but we patched our own fork of dacite to have it since it helps our team feel a little saner when resolving polymorphic union types. Let me know if you have comments or requests.

Add a config flag, no_ambiguous_resolution, to raise an error if a
dacite dataclass construction is being performed on a datatype which can
be resolved multiple ways.

I added a test also which demonstrates the situation that this flag can help catch.