### PR TITLE
types: add literal support for python 3.7

### DIFF
--- a/dacite/types.py
+++ b/dacite/types.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import InitVar
 from typing import Type, Any, Optional, Union, Collection, TypeVar, Dict, Callable, Mapping, List
 
@@ -65,7 +66,10 @@ def is_union(type_: Type) -> bool:
 
 def is_literal(type_: Type) -> bool:
     try:
-        from typing import Literal  # type: ignore
+        if sys.version_info >= (3, 8):
+            from typing import Literal
+        else:
+            from typing_extensions import Literal
 
         return is_generic(type_) and type_.__origin__ == Literal
     except ImportError:

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,4 +2,4 @@ import sys
 
 import pytest
 
-literal_support = init_var_type_support = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python 3.8")
+literal_support = init_var_type_support pytest.mark.skipif(sys.version_info < (3, 7), reason="requires Python 3.7")

--- a/tests/core/test_literal.py
+++ b/tests/core/test_literal.py
@@ -1,5 +1,12 @@
 from dataclasses import dataclass
+import sys
 from typing import Optional
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+elif sys.version_info < (3, 8) and sys.version_info > (3, 6):
+    from typing_extensions import Literal
+
 
 import pytest
 
@@ -10,8 +17,6 @@ from tests.common import literal_support
 
 @literal_support
 def test_from_dict_with_literal():
-    from typing import Literal
-
     @dataclass
     class X:
         l: Literal["A", "B"]
@@ -23,8 +28,6 @@ def test_from_dict_with_literal():
 
 @literal_support
 def test_from_dict_with_literal_and_wrong_value():
-    from typing import Literal
-
     @dataclass
     class X:
         l: Literal["A", "B"]
@@ -35,8 +38,6 @@ def test_from_dict_with_literal_and_wrong_value():
 
 @literal_support
 def test_from_dict_with_optional_literal_and_none():
-    from typing import Literal
-
     @dataclass
     class X:
         l: Optional[Literal["A", "B"]]
@@ -48,8 +49,6 @@ def test_from_dict_with_optional_literal_and_none():
 
 @literal_support
 def test_from_dict_with_optional_literal_and_not_none():
-    from typing import Literal
-
     @dataclass
     class X:
         l: Optional[Literal["A", "B"]]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,11 @@
+import sys
 from dataclasses import InitVar
 from typing import Optional, Union, List, Any, Dict, NewType, TypeVar, Generic, Collection, Tuple
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+elif sys.version_info < (3, 8) and sys.version_info > (3, 6):
+    from typing_extensions import Literal
 
 import pytest
 
@@ -31,8 +37,6 @@ def test_is_union_with_non_union():
 
 @literal_support
 def test_is_literal_with_literal():
-    from typing import Literal
-
     assert is_literal(Literal["A", "B"])
 
 
@@ -218,36 +222,26 @@ def test_is_instance_with_numeric_tower_and_new_type():
 
 @literal_support
 def test_is_instance_with_literal_and_matching_type():
-    from typing import Literal
-
     assert is_instance("A", Literal["A", "B"])
 
 
 @literal_support
 def test_is_instance_with_literal_and_not_matching_type():
-    from typing import Literal
-
     assert not is_instance("C", Literal["A", "B"])
 
 
 @literal_support
 def test_is_instance_with_optional_literal_and_matching_type():
-    from typing import Literal
-
     assert is_instance("A", Optional[Literal["A", "B"]])
 
 
 @literal_support
 def test_is_instance_with_optional_literal_and_not_matching_type():
-    from typing import Literal
-
     assert not is_instance("C", Optional[Literal["A", "B"]])
 
 
 @literal_support
 def test_is_instance_with_optional_literal_and_none():
-    from typing import Literal
-
     assert is_instance(None, Optional[Literal["A", "B"]])
 
 


### PR DESCRIPTION
Another quite small change - we are stuck on python 3.7 right now, which must backport Literal from typing_extensions 😒

Add literal support for python 3.7 by importing the Literal from
typing_extensions for python3.7.

