### PR TITLE
types: more general type hint for type_hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,7 @@ assert result == B(a_list=[A(x='test1', y=1), A(x='test2', y=2)])
 
 You can use `Config.type_hooks` argument if you want to transform the input 
 data of a data class field with given type into the new value. You have to 
-pass a following mapping: `{Type: callable}`, where `callable` is a 
-`Callable[[Any], Any]`.
+pass a mapping of type `Mapping[Type, Callable[[Any], Any]`.
 
 ```python
 @dataclass

--- a/dacite/config.py
+++ b/dacite/config.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
-from typing import Dict, Any, Callable, Optional, Type, List
+from typing import Dict, Any, Callable, Optional, Type, List, Mapping
 
 
 @dataclass
 class Config:
-    type_hooks: Dict[Type, Callable[[Any], Any]] = field(default_factory=dict)
+    type_hooks: Mapping[Type, Callable[[Any], Any]] = field(default_factory=dict)
     cast: List[Type] = field(default_factory=list)
     forward_references: Optional[Dict[str, Any]] = None
     check_types: bool = True

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -1,11 +1,11 @@
 from dataclasses import InitVar
-from typing import Type, Any, Optional, Union, Collection, TypeVar, Dict, Callable, Mapping, List, Tuple
+from typing import Type, Any, Optional, Union, Collection, TypeVar, Callable, Mapping, List, Tuple
 
 T = TypeVar("T", bound=Any)
 
 
 def transform_value(
-    type_hooks: Dict[Type, Callable[[Any], Any]], cast: List[Type], target_type: Type, value: Any
+    type_hooks: Mapping[Type, Callable[[Any], Any]], cast: List[Type], target_type: Type, value: Any
 ) -> Any:
     if target_type in type_hooks:
         value = type_hooks[target_type](value)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,3 +1,4 @@
+from collections.abc import MutableMapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, List, Union
@@ -11,6 +12,39 @@ from dacite import (
     UnexpectedDataError,
     StrictUnionMatchError,
 )
+
+
+class TypeHooksMapping(MutableMapping):
+    """
+    Simple mapping implementation which lets us test that Config.type_hooks may
+    be a Mapping, which is more general than the typical use case of being a
+    Dict.
+    """
+    def __init__(self, *args, **kwargs):
+        self.__dict__.update(*args, **kwargs)
+
+    def __getitem__(self, key):
+        if key in self.__dict__:
+            # If a type hook has been specified, use it.
+            return self.__dict__[key]
+        else:
+            # Otherwise, use a dummy type hook which always constructs a 1.
+            return lambda _: 1
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    def __delitem__(self):
+        if key in self.__dict__:
+            del self.__dict__[key]
+        else:
+            raise IndexError
+
+    def __len__(self):
+        return len(self.__dict__)
+
+    def __iter__(self):
+        return iter(self.__dict__)
 
 
 def test_from_dict_with_type_hooks():
@@ -41,6 +75,21 @@ def test_from_dict_with_type_hooks_and_union():
     result = from_dict(X, {"s": "TEST"}, Config(type_hooks={str: str.lower}))
 
     assert result == X(s="test")
+
+
+def test_type_hook_mapping():
+    @dataclass
+    class X:
+        s: str
+        i: int
+
+    result = from_dict(
+        X,
+        {"s": "TEST", "i": 0},
+        Config(type_hooks=TypeHooksMapping({str: str.lower}))
+    )
+
+    assert result == X(s="test", i=1)
 
 
 def test_from_dict_with_cast():


### PR DESCRIPTION
Update the type hint for type_hooks to accept the more general `Mapping` rather than `Dict`. It looks like `transform_value` will work with any `type_hooks` that supports `__iter__` or `__getitem__`, which the Mapping ABC / type signature requires that users do.

This makes the typechecker happier with us since I want to start using a Mapping implementation for a type_hooks that we use, to allow a little more flexibility. I can't think of any particular drawbacks to having a more general type hint here.

Out of self-interest, I added a test which I think will ensure dacite continues to support the use case I have in mind (tests a Mapping which is exactly like a dict but has an augmented `__getitem__` method).