### PR TITLE
Fix dacite.Config forward_references overriding get_type_hints()'s default globalns.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 dist/
 *.egg-info/
 build/
+/venv/
+/.idea/

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -43,7 +43,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     post_init_values: Data = {}
     config = config or Config()
     try:
-        data_class_hints = get_type_hints(data_class, globalns=config.forward_references)
+        data_class_hints = get_type_hints(data_class, localns=config.forward_references)
     except NameError as error:
         raise ForwardReferenceError(str(error))
     data_class_fields = get_fields(data_class)


### PR DESCRIPTION
A fix suggestion for the issue: https://github.com/konradhalas/dacite/issues/129