### PR TITLE
Added checking for union type

### DIFF
--- a/dacite/exceptions.py
+++ b/dacite/exceptions.py
@@ -1,8 +1,9 @@
 from typing import Any, Type, Optional, Set, Dict
+from dacite.types import is_union
 
 
 def _name(type_: Type) -> str:
-    return type_.__name__ if hasattr(type_, "__name__") else str(type_)
+    return type_.__name__ if hasattr(type_, "__name__") and not is_union(type_) else str(type_)
 
 
 class DaciteError(Exception):


### PR DESCRIPTION
Since python 3.10, Union type has a __name__ attribute, returning "Union" type, instead of "typing.Union[X, Y]" - to keep it backwards compatible (thus returning the old typing.Union type), it will be now stringified