### PR TITLE
Add GitHub Actions Code Check

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -1,0 +1,34 @@
+name: Code Check
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, edited, closed ]
+  push:
+    branches:
+      - master
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+
+    name: Python ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+      - name: Testing Check
+        run: pytest --cov=dacite
+      - name: Formatting Check
+        run: black --check .
+      - name: Typing Check
+        run: mypy dacite
+      - name: Linting Check
+        run: pylint dacite


### PR DESCRIPTION
Adding GitHub Actions Code Checks for Python 3.7, 3.8, 3.9, 3.10 with the same functionality as in [.travis.yml](https://github.com/konradhalas/dacite/blob/master/.travis.yml).
Publish step will be added in another PR.

This PR can be safely merged after merging #169 which fixes tests for Python 3.10.