### PR TITLE
Add GitHub Actions publish pipeline

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,21 @@
+name: publish
+on: release
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+          architecture: x64
+      - name: Build package
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This pipeline should deploy the package to PyPI on the new version release that can be made via GitHub UI. When making a release this way a new tag on the master branch can be created straight from the UI and the pipeline should run then. Exact process is described here: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository

@konradhalas if such a way of deployment suits you, please add an API token to this repo secrets with the name: `PYPI_API_TOKEN`. The process of creating the API token is described here: https://pypi.org/help/#apitoken