### PR TITLE
Added handling for sets, added tests

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -26,6 +26,7 @@ from dacite.types import (
     extract_origin_collection,
     is_init_var,
     extract_init_var,
+    is_set,
 )
 
 T = TypeVar("T")
@@ -86,8 +87,14 @@ def _build_value(type_: Type, data: Any, config: Config) -> Any:
         type_ = extract_init_var(type_)
     if is_union(type_):
         return _build_value_for_union(union=type_, data=data, config=config)
-    elif is_generic_collection(type_) and is_instance(data, extract_origin_collection(type_)):
-        return _build_value_for_collection(collection=type_, data=data, config=config)
+    elif is_generic_collection(type_):
+        origin = extract_origin_collection(type_)
+        if is_instance(data, origin):
+            return _build_value_for_collection(collection=type_, data=data, config=config)
+        if is_set(origin):
+            return origin(
+                _build_value(type_=extract_generic(type_)[0], data=single_val, config=config) for single_val in data
+            )
     elif is_dataclass(type_) and is_instance(data, Data):
         return from_dict(data_class=type_, data=data, config=config)
     return data

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -13,7 +13,10 @@ def transform_value(
         for cast_type in cast:
             if is_subclass(target_type, cast_type):
                 if is_generic_collection(target_type):
-                    value = extract_origin_collection(target_type)(value)
+                    origin_collection = extract_origin_collection(target_type)
+                    if is_set(origin_collection):
+                        return list(value)
+                    value = origin_collection(value)
                 else:
                     value = target_type(value)
                 break
@@ -82,6 +85,10 @@ def extract_new_type(type_: Type) -> Type:
 
 def is_init_var(type_: Type) -> bool:
     return isinstance(type_, InitVar) or type_ is InitVar
+
+
+def is_set(type_: Type) -> bool:
+    return type_ in (set, frozenset) or isinstance(type_, (frozenset, set))
 
 
 def extract_init_var(type_: Type) -> Union[Type, Any]:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -19,6 +19,7 @@ from dacite.types import (
     is_init_var,
     extract_init_var,
     is_type_generic,
+    is_set,
 )
 from tests.common import literal_support, init_var_type_support
 
@@ -385,3 +386,33 @@ def test_is_type_generic_with_matching_value():
 
 def test_is_type_generic_with_not_matching_value():
     assert not is_type_generic(int)
+
+
+def test_is_set_set_class():
+    assert is_set(set)
+
+
+def test_is_set_frozentset_class():
+    assert is_set(frozenset)
+
+
+def test_is_set_set_object():
+    obj = {1, 2, 3}
+    assert is_set(obj)
+
+
+def test_is_set_frozentset_object():
+    obj = frozenset({1, 2, 3})
+    assert is_set(obj)
+
+
+def test_is_set_list_class():
+    assert not is_set(list)
+
+
+def test_is_set_int_class():
+    assert not is_set(int)
+
+
+def test_is_set_union():
+    assert not is_set(Union[int, float])


### PR DESCRIPTION
Added handling of the sets conversion.
Since this library is to be kept light-weight, no "hack" was created for nested classes - in order for the classes to be hash-able inside the set, the user has to implement the __hash__ functionality of the class. For reference, check "_**test_from_dict_with_nested_set_classes**_" test inside [collection tests](https://github.com/konradhalas/dacite/pull/174/commits/4d9cdd923eca1c3a715870c5c24208bf65288ca9#diff-37c19584b8ed5affbbbc89549e0f2566d97e03de78aa413c0ac90b78d68685ee)