### PR TITLE
fix #168 empty tuple used for Sequence type

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -137,6 +137,8 @@ def _build_value_for_collection(collection: Type, data: Any, config: Config) -> 
         item_type = extract_generic(collection, defaults=(Any, Any))[1]
         return data_type((key, _build_value(type_=item_type, data=value, config=config)) for key, value in data.items())
     elif is_instance(data, tuple):
+        if not data:
+            return data_type()
         types = extract_generic(collection)
         if len(types) == 2 and types[1] == Ellipsis:
             return data_type(_build_value(type_=types[0], data=item, config=config) for item in data)

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -66,6 +66,10 @@ def is_union(type_: Type) -> bool:
     return is_generic(type_) and type_.__origin__ == Union
 
 
+def is_tuple(type_: Type) -> bool:
+    return is_subclass(type_, Tuple)
+
+
 def is_literal(type_: Type) -> bool:
     try:
         from typing import Literal  # type: ignore
@@ -109,7 +113,7 @@ def is_instance(value: Any, type_: Type) -> bool:
             return False
         if not extract_generic(type_):
             return True
-        if isinstance(value, tuple):
+        if isinstance(value, tuple) and is_tuple(type_):
             tuple_types = extract_generic(type_)
             if len(tuple_types) == 1 and tuple_types[0] == ():
                 return len(value) == 0

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,3 +3,4 @@ import sys
 import pytest
 
 literal_support = init_var_type_support = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python 3.8")
+type_hints_with_generic_collections_support = pytest.mark.skipif(sys.version_info < (3, 9), reason="requires Python 3.9")

--- a/tests/core/test_collection.py
+++ b/tests/core/test_collection.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Set, Union, Dict, Collection, Tuple
+from typing import List, Set, Union, Dict, Collection, Tuple, Sequence
 
 import pytest
 
@@ -269,3 +269,23 @@ def test_from_dict_with_tuple_and_implicit_any_types():
     result = from_dict(X, {"t": (1, 2, 3)})
 
     assert result == X(t=(1, 2, 3))
+
+
+def test_from_dict_with_sequence_and_tuple():
+    @dataclass
+    class X:
+        s: Sequence[int]
+
+    result = from_dict(X, {'s': (1, 2, 3)})
+
+    assert result == X(s=(1, 2, 3))
+
+
+def test_from_dict_with_sequence_and_empty_tuple():
+    @dataclass
+    class X:
+        s: Sequence[int]
+
+    result = from_dict(X, {'s': ()})
+
+    assert result == X(s=())

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -37,6 +37,18 @@ def test_is_tuple_with_tuple():
     assert is_tuple(Tuple[int, float, str])
 
 
+def test_is_tuple_with_variable_length_tuple():
+    assert is_tuple(Tuple[int, ...])
+
+
+def test_is_tuple_with_not_parametrized_tuple():
+    assert is_tuple(Tuple)
+
+
+def test_is_tuple_with_tuple_class_object():
+    assert is_tuple(tuple)
+
+
 def test_is_tuple_with_non_tuple():
     assert not is_tuple(int)
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -22,7 +22,7 @@ from dacite.types import (
     is_set,
     is_tuple,
 )
-from tests.common import literal_support, init_var_type_support
+from tests.common import literal_support, init_var_type_support, type_hints_with_generic_collections_support
 
 
 def test_is_union_with_union():
@@ -47,6 +47,16 @@ def test_is_tuple_with_not_parametrized_tuple():
 
 def test_is_tuple_with_tuple_class_object():
     assert is_tuple(tuple)
+
+
+@type_hints_with_generic_collections_support
+def test_is_tuple_with_tuple_generic():
+    assert is_tuple(tuple[int, float, str])
+
+
+@type_hints_with_generic_collections_support
+def test_is_tuple_with_variable_length_tuple_generic():
+    assert is_tuple(tuple[int, ...])
 
 
 def test_is_tuple_with_non_tuple():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -20,6 +20,7 @@ from dacite.types import (
     extract_init_var,
     is_type_generic,
     is_set,
+    is_tuple,
 )
 from tests.common import literal_support, init_var_type_support
 
@@ -30,6 +31,14 @@ def test_is_union_with_union():
 
 def test_is_union_with_non_union():
     assert not is_union(int)
+
+
+def test_is_tuple_with_tuple():
+    assert is_tuple(Tuple[int, float, str])
+
+
+def test_is_tuple_with_non_tuple():
+    assert not is_tuple(int)
 
 
 @literal_support


### PR DESCRIPTION
Fix proposal for #168 

Changes:
- is_instance checks tuple values types only if dataclass type hint is actually Tuple
- _build_value_for_collection returns () for empty tuple instead of (None,)
