### PR TITLE
fixed from_dict in case of frozen dataclass with non-init default

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -67,12 +67,14 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
                 raise
             if config.check_types and not is_instance(value, field.type):
                 raise WrongTypeError(field_path=field.name, field_type=field.type, value=value)
+        elif not field.init:
+            # If the non-init field isn't in the dict, let the dataclass handle default, to ensure
+            # we won't get errors in the case of frozen dataclasses, as issue #195 highlights.
+            continue
         else:
             try:
                 value = get_default_value_for_field(field)
             except DefaultValueNotFoundError:
-                if not field.init:
-                    continue
                 raise MissingValueError(field.name)
         if field.init:
             init_values[field.name] = value

--- a/tests/core/test_frozen_non_init_var.py
+++ b/tests/core/test_frozen_non_init_var.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass, field
+
+from dacite import from_dict
+
+
+def test_from_dict_with_frozen_non_init_var_with_default():
+    @dataclass(frozen=True)
+    class X:
+        a: int = field(init=False, default=5)
+
+    result = from_dict(X, {})
+
+    assert result.a == 5


### PR DESCRIPTION
Small fix to `from_dict` to fix the case where:
- A dataclass is frozen
- It contains a non-init field
- The non-init field has a default value
- The input `data` dict doesn't contain this field

Test `tests/core/test_frozen_non_init_var::test_from_dict_with_frozen_non_init_var_with_default` added

closes #195 