### PR TITLE
Introduce basic cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ build/
 
 venv*
 
+.benchmarks
 benchmark.json

--- a/README.md
+++ b/README.md
@@ -407,6 +407,12 @@ Install all `dacite` dependencies:
 $ pip install -e .[dev]
 ```
 
+And, optionally but recommended, install pre-commit hook for black:
+
+```
+$ pre-commit install
+```
+
 To run tests you just have to fire:
 
 ```

--- a/dacite/cache.py
+++ b/dacite/cache.py
@@ -1,0 +1,14 @@
+from functools import lru_cache
+from typing import TypeVar, Callable
+
+T = TypeVar("T", bound=Callable)
+
+
+class Cache:
+    @lru_cache(maxsize=None)
+    def cache(self, function: T) -> T:
+        return lru_cache(maxsize=None)(function)
+
+    @lru_cache(maxsize=None)
+    def cache_from_factory(self, function: Callable[["Cache"], T]) -> T:
+        return function(self)

--- a/dacite/cache.py
+++ b/dacite/cache.py
@@ -8,7 +8,3 @@ class Cache:
     @lru_cache(maxsize=None)
     def cache(self, function: T) -> T:
         return lru_cache(maxsize=None)(function)
-
-    @lru_cache(maxsize=None)
-    def cache_from_factory(self, function: Callable[["Cache"], T]) -> T:
-        return function(self)

--- a/dacite/config.py
+++ b/dacite/config.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Dict, Any, Callable, Optional, Type, List
 
+from dacite.cache import Cache
+
 
 @dataclass
 class Config:
@@ -10,3 +12,4 @@ class Config:
     check_types: bool = True
     strict: bool = False
     strict_unions_match: bool = False
+    cache: Cache = Cache()

--- a/dacite/config.py
+++ b/dacite/config.py
@@ -1,7 +1,9 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
+from functools import cached_property
 from typing import Dict, Any, Callable, Optional, Type, List
 
 from dacite.cache import Cache
+from dacite.frozen_dict import FrozenDict
 
 
 @dataclass
@@ -13,3 +15,7 @@ class Config:
     strict: bool = False
     strict_unions_match: bool = False
     cache: Cache = Cache()
+
+    @cached_property
+    def hashable_forward_references(self) -> Optional[FrozenDict]:
+        return FrozenDict(self.forward_references) if self.forward_references else None

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,7 +1,7 @@
 import copy
 from dataclasses import is_dataclass
 from itertools import zip_longest
-from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection
+from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, Dict
 
 from dacite.config import Config
 from dacite.data import Data
@@ -22,6 +22,7 @@ from dacite.exceptions import (
     UnexpectedDataError,
     StrictUnionMatchError,
 )
+from dacite.frozen_dict import FrozenDict
 from dacite.types import (
     is_instance,
     is_generic_collection,
@@ -45,11 +46,11 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
     :param config: a configuration of the creation process
     :return: an instance of a data class
     """
-    init_values: Data = {}
-    post_init_values: Data = {}
+    init_values: Dict[str, Any] = {}
+    post_init_values: Dict[str, Any] = {}
     config = config or Config()
     try:
-        data_class_hints = get_type_hints(data_class, globalns=config.forward_references)
+        data_class_hints = config.cache.cache(get_type_hints)(data_class, localns=config.hashable_forward_references)
     except NameError as error:
         raise ForwardReferenceError(str(error))
     data_class_fields = config.cache.cache(get_fields)(data_class)

--- a/dacite/data.py
+++ b/dacite/data.py
@@ -1,3 +1,3 @@
-from typing import Dict, Any
+from typing import Mapping
 
-Data = Dict[str, Any]
+Data = Mapping

--- a/dacite/frozen_dict.py
+++ b/dacite/frozen_dict.py
@@ -1,0 +1,34 @@
+from collections.abc import Mapping
+
+
+class FrozenDict(Mapping):
+    dict_cls = dict
+
+    def __init__(self, *args, **kwargs):
+        self._dict = self.dict_cls(*args, **kwargs)
+        self._hash = None
+
+    def __getitem__(self, key):
+        return self._dict[key]
+
+    def __contains__(self, key):
+        return key in self._dict
+
+    def copy(self, **add_or_replace):
+        return self.__class__(self, **add_or_replace)
+
+    def __iter__(self):
+        return iter(self._dict)
+
+    def __len__(self):
+        return len(self._dict)
+
+    def __repr__(self):
+        return "<%s %r>" % (self.__class__.__name__, self._dict)
+
+    def __hash__(self):
+        if self._hash is None:
+            self._hash = 0
+            for key, value in self._dict.items():
+                self._hash ^= hash((key, value))
+        return self._hash

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,17 +11,3 @@ def test_cache_from_function():
     cache.cache(function)()
 
     function.assert_called_once()
-
-
-def test_cache_from_factory():
-    function = Mock()
-
-    def function_factory(c):
-        return c.cache(function)
-
-    cache = Cache()
-
-    cache.cache_from_factory(function_factory)()
-    cache.cache_from_factory(function_factory)()
-
-    function.assert_called_once()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,27 @@
+from unittest.mock import Mock
+
+from dacite.cache import Cache
+
+
+def test_cache_from_function():
+    function = Mock()
+    cache = Cache()
+
+    cache.cache(function)()
+    cache.cache(function)()
+
+    function.assert_called_once()
+
+
+def test_cache_from_factory():
+    function = Mock()
+
+    def function_factory(c):
+        return c.cache(function)
+
+    cache = Cache()
+
+    cache.cache_from_factory(function_factory)()
+    cache.cache_from_factory(function_factory)()
+
+    function.assert_called_once()


### PR DESCRIPTION
I salvaged some useful parts from `feature/performance-improvements` branch:

* Introduced `Cache` class.
* Introduced `FrozenDict` class to allow caching dictionaries (which are non-hashable by default).
* Cache `get_type_hints` call. Also changed `globalns` to `localns`, because `globalns` only accepts a real `dict`, while `localns` can get `FrozenDict` without any issues.
* Cache `get_fields` call.