### PR TITLE
Feature/handle generics

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -50,4 +50,4 @@ jobs:
           comment-always: false
           alert-threshold: '130%'
           comment-on-alert: false
-          fail-on-alert: false
+          fail-on-alert: ${{ !inputs.publish_performance }}

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -50,4 +50,4 @@ jobs:
           comment-always: false
           alert-threshold: '130%'
           comment-on-alert: false
-          fail-on-alert: true
+          fail-on-alert: false

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -64,8 +64,8 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
             raise UnexpectedDataError(keys=extra_fields)
     for field in data_class_fields:
         field_type = data_class_hints[field.name]
-        if hasattr(data, field.name) or (isinstance(data, Mapping) and field.name in data):
-            field_data = getattr(data, field.name, None) or data[field.name]
+        if field.name in data:
+            field_data = data[field.name]
             try:
                 value = _build_value(type_=field_type, data=field_data, config=config)
             except DaciteFieldError as error:

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,6 +1,11 @@
 from dataclasses import is_dataclass
 from itertools import zip_longest
-from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, MutableMapping, get_origin
+from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, MutableMapping
+
+try:
+    from typing import get_origin  # type: ignore
+except ImportError:
+    from typing_extensions import get_origin
 
 from dacite.cache import cache
 from dacite.config import Config
@@ -99,7 +104,9 @@ def _build_value(type_: Type, data: Any, config: Config) -> Any:
     elif cache(is_dataclass)(type_) and isinstance(data, Mapping):
         data = from_dict(data_class=type_, data=data, config=config)
     elif is_generic_subclass(type_) and is_dataclass(get_origin(type_)):
-        data = from_dict(data_class=get_origin(type_), data=data, config=config)
+        origin = get_origin(type_)
+        assert origin is not None
+        data = from_dict(data_class=origin, data=data, config=config)
     for cast_type in config.cast:
         if is_subclass(type_, cast_type):
             if is_generic_collection(type_):

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -103,7 +103,7 @@ def _build_value(type_: Type, data: Any, config: Config) -> Any:
         data = _build_value_for_collection(collection=type_, data=data, config=config)
     elif cache(is_dataclass)(type_) and isinstance(data, Mapping):
         data = from_dict(data_class=type_, data=data, config=config)
-    elif is_generic_subclass(type_) and is_dataclass(get_origin(type_)):
+    elif is_generic_subclass(type_) and cache(is_dataclass)(get_origin(type_)):
         origin = get_origin(type_)
         assert origin is not None
         data = from_dict(data_class=origin, data=data, config=config)

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -5,7 +5,7 @@ from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collec
 try:
     from typing import get_origin  # type: ignore
 except ImportError:
-    from typing_extensions import get_origin
+    from typing_extensions import get_origin  # type: ignore
 
 from dacite.cache import cache
 from dacite.config import Config

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -4,7 +4,7 @@ from typing import Type, Any, Optional, Union, Collection, TypeVar, Mapping, Tup
 try:
     from typing import get_origin, get_args  # type: ignore
 except ImportError:
-    from typing_extensions import get_origin, get_args
+    from typing_extensions import get_origin, get_args  # type: ignore
 from inspect import isclass
 
 from dacite.cache import cache

--- a/dacite/types.py
+++ b/dacite/types.py
@@ -230,7 +230,7 @@ def is_subclass(sub_type: Type, base_type: Type) -> bool:
     if is_generic_collection(sub_type):
         sub_type = extract_origin_collection(sub_type)
     try:
-        return issubclass(sub_type, base_type)
+        return cache(issubclass)(sub_type, base_type)
     except TypeError:
         return False
 

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -267,4 +267,6 @@ def test_dataclass_default_factory_identity():
     a1 = from_dict(A, {"name": "a1"})
     a2 = from_dict(A, {"name": "a2"})
 
+    assert a1 is not a2
+    assert a1.name is not a2.name
     assert a1.items is not a2.items

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -193,7 +193,7 @@ def test_from_dict_with_new_type():
     assert result == X(s=MyStr("test"))
 
 
-def test_from_dict_generic():
+def test_from_dict_generic_valid():
     T = TypeVar("T", bound=Union[str, int])
 
     @dataclass

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,4 @@
-from dataclasses import InitVar
+from dataclasses import InitVar, dataclass
 from typing import Optional, Union, List, Any, Dict, NewType, TypeVar, Generic, Collection, Tuple, Type
 from unittest.mock import patch, Mock
 
@@ -268,13 +268,13 @@ def test_is_instance_with_with_type_and_not_matching_value_type():
     assert not is_instance(1, Type[str])
 
 
-def test_is_instance_with_not_supported_generic_types():
+def test_is_instance_with_generic_types():
     T = TypeVar("T")
 
     class X(Generic[T]):
         pass
 
-    assert not is_instance(X[str](), X[str])
+    assert is_instance(X[str](), X[str])
 
 
 def test_is_instance_with_generic_mapping_and_matching_value_type():
@@ -362,6 +362,10 @@ def test_is_instance_with_empty_tuple_and_matching_type():
 
 def test_is_instance_with_empty_tuple_and_not_matching_type():
     assert not is_instance((1, 2), Tuple[()])
+
+
+def test_is_instance_list_type():
+    assert is_instance([{}], List)
 
 
 def test_extract_generic():


### PR DESCRIPTION
This is a draft PR for introducing the handling of typing generics. Feel free to review this PR, but keep in mind it is not yet finished—publishing it just for the sake of code reviews and brainstorming.

Fixes #131
Fixes #157 
Fixes #160

## TODO

- [ ] Add much more test cases that use `typing.Generic` and `typing.TypeVar`.
- [ ] Consider handling other typing shenanigans, like `Annotated`, `TypeAlias`, `TypeVarTuple`.
- [x] Backport `typing.get_origin` and `typing.get_args` for lower Python versions.
- [x] Refactor and clean up the code, it's super ugly at the moment.
- [ ] Consider using `typing. TypeGuard` for typehinting the `is_instance` and its related functions.