### PR TITLE
Remove @cache decorator from get_default_value_for_field

### DIFF
--- a/dacite/dataclasses.py
+++ b/dacite/dataclasses.py
@@ -11,7 +11,6 @@ class DefaultValueNotFoundError(Exception):
     pass
 
 
-@cache
 def get_default_value_for_field(field: Field, type_: Type) -> Any:
     if field.default != MISSING:
         return field.default

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, NewType, Optional
+from typing import Any, NewType, Optional, List
 
 import pytest
 
@@ -198,7 +198,7 @@ def test_dataclass_default_factory_identity():
     @dataclass
     class A:
         name: str
-        items: list[str] = field(default_factory=list)
+        items: List[str] = field(default_factory=list)
 
     a1 = from_dict(A, {"name": "a1"})
     a2 = from_dict(A, {"name": "a2"})

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -191,3 +191,16 @@ def test_from_dict_with_new_type():
     result = from_dict(X, {"s": "test"})
 
     assert result == X(s=MyStr("test"))
+
+
+def test_dataclass_default_factory_identity():
+    # https://github.com/konradhalas/dacite/issues/215
+    @dataclass
+    class A:
+        name: str
+        items: list[str] = field(default_factory=list)
+
+    a1 = from_dict(A, {"name": "a1"})
+    a2 = from_dict(A, {"name": "a2"})
+
+    assert a1.items is not a2.items


### PR DESCRIPTION
Fixes #215 

We went one cache too far 😓  This should not hurt performance that much I think. A good `v1.81` candidate.