### PR TITLE
Allow type_hooks for substituted objects of the same parent type

### DIFF
--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install dependencies
-        run: pip install -e ".[dev,freezegun]"
+        run: pip install -e ".[dev]"
       - name: Testing Check
         run: pytest --cov=dacite
       - name: Formatting Check

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,freezegun]"
       - name: Testing Check
         run: pytest --cov=dacite
       - name: Formatting Check

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -83,12 +83,16 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
         setattr(instance, key, value)
     return instance
 
+def transform_by_type_hooks(data: Any, type_: Type, type_hooks: Dict[Type, Callable[[Any], Any]]):
+    for th, func in type_hooks.items():
+        if is_subclass(th, type_):
+            return func(data)    
 
 def _build_value(type_: Type, data: Any, config: Config) -> Any:
     if is_init_var(type_):
         type_ = extract_init_var(type_)
-    if type_ in config.type_hooks:
-        data = config.type_hooks[type_](data)
+    if transformed := transform_by_type_hooks(data, type_, config.type_hooks):
+        data = transformed
     if is_optional(type_) and data is None:
         return data
     if is_union(type_):

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,15 +1,6 @@
 from dataclasses import is_dataclass
 from itertools import zip_longest
-from typing import (
-    TypeVar,
-    Type,
-    Optional,
-    get_type_hints,
-    Mapping,
-    Any,
-    Collection,
-    MutableMapping,
-)
+from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, MutableMapping
 
 from dacite.cache import cache
 from dacite.config import Config

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -4,8 +4,6 @@ from typing import (
     TypeVar,
     Type,
     Optional,
-    Union,
-    get_origin,
     get_type_hints,
     Mapping,
     Any,
@@ -99,8 +97,8 @@ def _build_value(type_: Type, data: Any, config: Config) -> Any:
     if is_init_var(type_):
         type_ = extract_init_var(type_)
     if not is_union(type_):
-        for th, func in config.type_hooks.items():
-            if is_subclass(th, type_):
+        for th_type, func in config.type_hooks.items():
+            if is_subclass(th_type, type_):
                 data = func(data)
     if is_optional(type_) and data is None:
         return data

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -98,7 +98,7 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
 def _build_value(type_: Type, data: Any, config: Config) -> Any:
     if is_init_var(type_):
         type_ = extract_init_var(type_)
-    if get_origin(type_) is not Union:
+    if not is_union(type_):
         for th, func in config.type_hooks.items():
             if is_subclass(th, type_):
                 data = func(data)

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,6 +1,6 @@
 from dataclasses import is_dataclass
 from itertools import zip_longest
-from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, MutableMapping
+from typing import Callable, TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, MutableMapping
 
 from dacite.cache import cache
 from dacite.config import Config
@@ -83,10 +83,12 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
         setattr(instance, key, value)
     return instance
 
-def transform_by_type_hooks(data: Any, type_: Type, type_hooks: Dict[Type, Callable[[Any], Any]]):
+
+def transform_by_type_hooks(data: Any, type_: Type, type_hooks: dict[Type, Callable[[Any], Any]]) -> Any | None:
     for th, func in type_hooks.items():
         if is_subclass(th, type_):
-            return func(data)    
+            return func(data)
+
 
 def _build_value(type_: Type, data: Any, config: Config) -> Any:
     if is_init_var(type_):

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,6 +1,18 @@
 from dataclasses import is_dataclass
 from itertools import zip_longest
-from typing import Callable, TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, MutableMapping
+from typing import (
+    Callable,
+    TypeVar,
+    Type,
+    Optional,
+    Union,
+    get_origin,
+    get_type_hints,
+    Mapping,
+    Any,
+    Collection,
+    MutableMapping,
+)
 
 from dacite.cache import cache
 from dacite.config import Config
@@ -85,6 +97,8 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
 
 
 def transform_by_type_hooks(data: Any, type_: Type, type_hooks: dict[Type, Callable[[Any], Any]]) -> Any | None:
+    if get_origin(type_) is Union:
+        return
     for th, func in type_hooks.items():
         if is_subclass(th, type_):
             return func(data)


### PR DESCRIPTION
We've had issues with dacite not supporting `type_hooks` on `datetime` during testing, when `freezegun` is monkey patching the `datetime` object to be `FakeDatetime`, see [here](https://github.com/konradhalas/dacite/issues/185). 

At first it was assumed that the dataclass attribute was monkey patched and therefore the `type_hooks` list doesn't have a match for the attribute's type. However this is not the case, as the interpreter would have already interpreted the type annotation before the monkey patch takes place, taking a reference to the original object. 
It is instead the `type_hooks`' key (which for clarity is not a string but instead the data type itself) that is patched. Thus on structuring data into a dataclass, the `type_hooks` dict contains a `FakeDatetime` key to an `isoparse` hook.

Last bit of context needed before going to the proposed fix: the way type hooks are matched with dataclass's attributes's types in dacite today is by `in`, which is like iterating over the keys and doing a value comparison (`==`, not `is`). This does however not allow us to have objects to be replaced following the [Liskov Principle](https://en.wikipedia.org/wiki/Liskov_substitution_principle), whereby we can substitute an object of one type by another so long as they share the same parent (simplified for brevity, sufficient for this context). 

Coming to the proposal: If we change the way we compare type_hooks with "is a ..." logic instead of "==" logic, we can substitute objects that should provide the same behaviour.

Getting back to the original problem, freezegun. Since Python allows us to redefine the behaviour of objects via meta classes, we can create objects that aren't actual drop-ins but will still declare themselves as a subclass of another type. This is exactly [what freezegun is doing here](https://github.com/spulec/freezegun/blob/master/freezegun/api.py#L340). This object is not a subclass of `datetime.datetime` by inheritance, instead by explicitly overriding the comparison made by `issubclass`. With the proposed change, this means we can monkey patch `datetime.datetime` to `FakeDateTime` and still have a matching type hook in the `type_hooks` dict. I imagine this will be helpful for a lot more cases where monkey patching is happening with objects defined in a similar way. 