### PR TITLE
add possibility use keywords from reserved names. 

### DIFF
--- a/dacite/config.py
+++ b/dacite/config.py
@@ -19,6 +19,7 @@ class Config:
     check_types: bool = True
     strict: bool = False
     strict_unions_match: bool = False
+    reserved_names: bool = False
 
     @cached_property
     def hashable_forward_references(self) -> Optional[FrozenDict]:

--- a/dacite/core.py
+++ b/dacite/core.py
@@ -1,6 +1,7 @@
 from dataclasses import is_dataclass
 from itertools import zip_longest
 from typing import TypeVar, Type, Optional, get_type_hints, Mapping, Any, Collection, MutableMapping
+import keyword
 
 from dacite.cache import cache
 from dacite.config import Config
@@ -58,6 +59,11 @@ def from_dict(data_class: Type[T], data: Data, config: Optional[Config] = None) 
             raise UnexpectedDataError(keys=extra_fields)
     for field in data_class_fields:
         field_type = data_class_hints[field.name]
+
+        if config.reserved_names and not field.name in data:
+            if field.name[-1] == "_" and keyword.iskeyword(field.name[:-1]) and field.name[:-1] in data:
+                data[field.name] = data.pop(field.name[:-1])
+
         if field.name in data:
             try:
                 field_data = data[field.name]


### PR DESCRIPTION
i want to load json with key name 'from', make dataclasse with field "from_" and load it if config.reserved_names is True
i found that nessesary when worked with JIRA API
it returns change history json
```
    data = {
                "field": "IssueParentAssociation",
                "fieldtype": "jira",
                "from": "88223",
                "fromString": "PRJ-1",
                "to": "88222",
                "toString": "PRJ-2"
              }
```

then make dataclass
```
@dataclass
class HistoryItemJson:
    field: str
    fieldtype: str
    fieldId: Optional[str]
    from_: Optional[str]
    fromString: Optional[str]
    to: Optional[str]
    toString: Optional[str]
```


and simply load it
`result: HistoryItemJson = from_dict(data_class=HistoryItemJson, data=data, config=Config(type_hooks={datetime: datetime.fromisoformat}, reserved_names=True))`