### PR TITLE
Better error messages for nested structs

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -139,17 +139,42 @@ def _build_value_for_collection(collection: Type, data: Any, config: Config) -> 
     data_type = data.__class__
     if isinstance(data, Mapping) and is_subclass(collection, Mapping):
         item_type = extract_generic(collection, defaults=(Any, Any))[1]
-        return data_type((key, _build_value(type_=item_type, data=value, config=config)) for key, value in data.items())
+        items = []
+        for key, value in data.items():
+            try:
+                items.append((key, _build_value(type_=item_type, data=value, config=config)))
+            except DaciteFieldError as error:
+                error.update_path(f"[{key}]")
+                raise
+        return data_type(items)
     elif isinstance(data, tuple) and is_subclass(collection, tuple):
         if not data:
             return data_type()
         types = extract_generic(collection)
+        items = []
         if len(types) == 2 and types[1] == Ellipsis:
-            return data_type(_build_value(type_=types[0], data=item, config=config) for item in data)
-        return data_type(
-            _build_value(type_=type_, data=item, config=config) for item, type_ in zip_longest(data, types)
-        )
+            for i, item in enumerate(data):
+                try:
+                    items.append(_build_value(type_=types[0], data=item, config=config))
+                except DaciteFieldError as error:
+                    error.update_path(f"[{i}]")
+                    raise
+            return data_type(items)
+        for i, (item, type_) in enumerate(zip_longest(data, types)):
+            try:
+                items.append(_build_value(type_=type_, data=item, config=config))
+            except DaciteFieldError as error:
+                error.update_path(f"[{i}]")
+                raise
+        return data_type(items)
     elif isinstance(data, Collection) and is_subclass(collection, Collection):
         item_type = extract_generic(collection, defaults=(Any,))[0]
-        return data_type(_build_value(type_=item_type, data=item, config=config) for item in data)
+        items = []
+        for i, item in enumerate(data):
+            try:
+                items.append(_build_value(type_=item_type, data=item, config=config))
+            except DaciteFieldError as error:
+                error.update_path(f"[{i}]")
+                raise
+        return data_type(items)
     return data

--- a/dacite/exceptions.py
+++ b/dacite/exceptions.py
@@ -17,7 +17,10 @@ class DaciteFieldError(DaciteError):
 
     def update_path(self, parent_field_path: str) -> None:
         if self.field_path:
-            self.field_path = f"{parent_field_path}.{self.field_path}"
+            if self.field_path.startswith("["):
+                self.field_path = f"{parent_field_path}{self.field_path}"
+            else:
+                self.field_path = f"{parent_field_path}.{self.field_path}"
         else:
             self.field_path = parent_field_path
 


### PR DESCRIPTION
- dicts now have the key name in them
- lists/tuples now have the index in them

Old error message:

```
dacite.exceptions.WrongTypeError: wrong value type for field "t.t2.name" - should be "str" instead of value "1" of type "int"
```

New error message:

```
dacite.exceptions.WrongTypeError: wrong value type for field "t[name].t2[0].name" - should be "str" instead of value "1" of type "int"
```