### PR TITLE
Fix issues with caching internal function calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+- Fix issues with caching internal function calls
 
 ## [1.8.1] - 2023-05-12
 

--- a/dacite/cache.py
+++ b/dacite/cache.py
@@ -8,7 +8,7 @@ __MAX_SIZE: Optional[int] = 2048
 
 @lru_cache(maxsize=None)
 def cache(function: T) -> T:
-    return lru_cache(maxsize=get_cache_size())(function)  # type: ignore
+    return lru_cache(maxsize=get_cache_size(), typed=True)(function)  # type: ignore
 
 
 def set_cache_size(size: Optional[int]) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -399,3 +399,8 @@ def test_extract_generic_special():
         _special = True
 
     assert extract_generic(FakeType, defaults) == defaults
+
+
+def test_optional_and_union_none_does_not_pollute_scope_via_caching():
+    is_generic(Optional[str])
+    is_generic_collection(str | None)


### PR DESCRIPTION
It seems that adding the `typed=True` to `lru_cache` helps for the internal function calls issues.

This solves at least the following issue https://github.com/konradhalas/dacite/issues/236 (took the test itself from there) but possibly some others.