### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci_master.yaml
+++ b/.github/workflows/ci_master.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/ci_pr.yaml
+++ b/.github/workflows/ci_pr.yaml
@@ -2,6 +2,7 @@ name: CI Pull Request
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -44,7 +44,7 @@ jobs:
           tool: 'pytest'
           output-file-path: benchmark.json
           save-data-file: ${{ inputs.store_benchmark }}
-          github-token: ${{ secrets.benchmark_token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: ${{ inputs.publish_performance }}
           benchmark-data-dir-path: performance/${{ matrix.python-version }}
           comment-always: false

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -402,7 +402,7 @@ def test_extract_generic_special():
     assert extract_generic(FakeType, defaults) == defaults
 
 
-@pytest.mark.skipif(version_info < (3, 10), reason="requires python3.10")
+@pytest.mark.skipif(version_info < (3, 10), reason="writing union types as X | Y requires Python 3.10")
 def test_optional_and_union_none_does_not_pollute_scope_via_caching():
     is_generic(Optional[str])
     is_generic_collection(str | None)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,4 +1,5 @@
 from dataclasses import InitVar
+from sys import version_info
 from typing import Optional, Union, List, Any, Dict, NewType, TypeVar, Generic, Collection, Tuple, Type
 from unittest.mock import patch, Mock
 
@@ -401,6 +402,7 @@ def test_extract_generic_special():
     assert extract_generic(FakeType, defaults) == defaults
 
 
+@pytest.mark.skipif(version_info < (3, 10), reason="requires python3.10")
 def test_optional_and_union_none_does_not_pollute_scope_via_caching():
     is_generic(Optional[str])
     is_generic_collection(str | None)


### PR DESCRIPTION
* [Allow manual runs](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow)
* Skip `test_optional_and_union_none_does_not_pollute_scope_via_caching()`, which uses new syntax, on Python < 3.10
* [Use automatic token authentication](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication). Fixes #267.