### PR TITLE
Update actions versions, add Python 3.12 and 3.13 to test matrix

### DIFF
--- a/.github/workflows/ci_master.yaml
+++ b/.github/workflows/ci_master.yaml
@@ -9,8 +9,7 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/code_check.yaml
-    secrets:
-      benchmark_token: ${{ secrets.BENCHMARK_TOKEN }}
+    secrets: inherit
     with:
       publish_performance: true
       store_benchmark: true

--- a/.github/workflows/ci_pr.yaml
+++ b/.github/workflows/ci_pr.yaml
@@ -7,8 +7,7 @@ on:
 jobs:
   ci:
     uses: ./.github/workflows/code_check.yaml
-    secrets:
-      benchmark_token: ${{ secrets.BENCHMARK_TOKEN }}
+    secrets: inherit
     with:
       publish_performance: false
       store_benchmark: false

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']

--- a/.github/workflows/code_check.yaml
+++ b/.github/workflows/code_check.yaml
@@ -2,9 +2,6 @@ name: Code Check
 
 on:
   workflow_call:
-    secrets:
-      benchmark_token:
-        required: true
     inputs:
       publish_performance:
         required: true
@@ -18,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
 
     name: Python ${{ matrix.python-version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,8 +7,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           architecture: x64


### PR DESCRIPTION
- Updated some external Github Actions (namely `checkout` and `setup-python`).
- Added Python 3.12 and 3.13 to the test matrix.
- Pinned runners to Ubuntu 22.04 to fix Python 3.7 missing.