### PR TITLE
Do not assign to hint.__args__ if concretized hint_args are the same

### DIFF
--- a/dacite/generics.py
+++ b/dacite/generics.py
@@ -58,9 +58,10 @@ def __concretize(
     if hint_origin and hint_args and hint_origin is not Literal:
         concretized = tuple(__concretize(a, generics, data_class) for a in hint_args)
         if concretized != hint_args:
-            # FIXME: Are there scenarios where concretized != hint_args, but hint.__args__ is readonly?
-            #        Then it will still fail!
-            hint.__args__ = concretized
+            try:
+                hint.__args__ = concretized
+            except AttributeError as e:
+                raise DaciteError(f"Could not set __args__ on {hint} [original error: {e}]") from None
 
     return hint
 

--- a/dacite/generics.py
+++ b/dacite/generics.py
@@ -56,7 +56,11 @@ def __concretize(
     hint_origin = get_origin(hint)
     hint_args = get_args(hint)
     if hint_origin and hint_args and hint_origin is not Literal:
-        hint.__args__ = tuple(__concretize(a, generics, data_class) for a in hint_args)
+        concretized = tuple(__concretize(a, generics, data_class) for a in hint_args)
+        if concretized != hint_args:
+            # FIXME: Are there scenarios where concretized != hint_args, but hint.__args__ is readonly?
+            #        Then it will still fail!
+            hint.__args__ = concretized
 
     return hint
 

--- a/dacite/generics.py
+++ b/dacite/generics.py
@@ -60,8 +60,8 @@ def __concretize(
         if concretized != hint_args:
             try:
                 hint.__args__ = concretized
-            except AttributeError as e:
-                raise DaciteError(f"Could not set __args__ on {hint} [original error: {e}]") from None
+            except AttributeError as err:
+                raise DaciteError(f"Could not set __args__ on {hint} [original error: {err}]") from None
 
     return hint
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -4,6 +4,6 @@ import pytest
 
 literal_support = init_var_type_support = pytest.mark.skipif(sys.version_info < (3, 8), reason="requires Python 3.8")
 pep_604_support = pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10")
-type_hints_with_generic_collections_support = pytest.mark.skipif(
+type_hints_with_generic_collections_support = type_hinting_using_standard_collections = pytest.mark.skipif(
     sys.version_info < (3, 9), reason="requires Python 3.9"
 )

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -4,22 +4,26 @@ from typing import Any, NewType, Optional, List
 import pytest
 
 from dacite import from_dict, MissingValueError, WrongTypeError
+from tests.common import type_hinting_using_standard_collections
 
 
-def test_from_dict_iterables():
+def test_from_dict_iterables_with_typing_list():
     @dataclass
     class Foo:
-        bar: list[str]
-
-    @dataclass
-    class Foo2:
         bar: List[str]
 
     result = from_dict(Foo, {"bar": ["foo", "bar"]})
     assert result == Foo(bar=["foo", "bar"])
 
-    result_2 = from_dict(Foo2, {"bar": ["foo", "bar"]})
-    assert result_2 == Foo2(bar=["foo", "bar"])
+
+@type_hinting_using_standard_collections
+def test_from_dict_iterables():
+    @dataclass
+    class Foo:
+        bar: list[str]
+
+    result = from_dict(Foo, {"bar": ["foo", "bar"]})
+    assert result == Foo(bar=["foo", "bar"])
 
 
 def test_from_dict_with_correct_data():

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -6,6 +6,22 @@ import pytest
 from dacite import from_dict, MissingValueError, WrongTypeError
 
 
+def test_from_dict_iterables():
+    @dataclass
+    class Foo:
+        bar: list[str]
+
+    @dataclass
+    class Foo2:
+        bar: List[str]
+
+    result = from_dict(Foo, {"bar": ["foo", "bar"]})
+    assert result == Foo(bar=["foo", "bar"])
+
+    result_2 = from_dict(Foo2, {"bar": ["foo", "bar"]})
+    assert result_2 == Foo2(bar=["foo", "bar"])
+
+
 def test_from_dict_with_correct_data():
     @dataclass
     class X:


### PR DESCRIPTION
Fixes #273 