### PR TITLE
fix readonly __args__

### DIFF
--- a/dacite/config.py
+++ b/dacite/config.py
@@ -4,7 +4,7 @@ from typing import Dict, Any, Callable, Optional, Type, List
 
 from dacite.frozen_dict import FrozenDict
 
-if sys.version_info.minor >= 8:
+if sys.version_info >= (3, 8):
     from functools import cached_property  # type: ignore  # pylint: disable=no-name-in-module
 else:
     # Remove when we drop support for Python<3.8


### PR DESCRIPTION
You could have a try if this works for python 3.12.x and 3.13.x. This was actually my original code for python 3.9.13, but it as not supported by python 3.8. 