### PR TITLE
Fix type_hooks handling for dictionary keys

### DIFF
--- a/dacite/core.py
+++ b/dacite/core.py
@@ -146,8 +146,14 @@ def _build_value_for_union(union: Type, data: Any, config: Config) -> Any:
 def _build_value_for_collection(collection: Type, data: Any, config: Config) -> Any:
     data_type = data.__class__
     if isinstance(data, Mapping) and is_subclass(collection, Mapping):
-        item_type = extract_generic(collection, defaults=(Any, Any))[1]
-        return data_type((key, _build_value(type_=item_type, data=value, config=config)) for key, value in data.items())
+        key_type, item_type = extract_generic(collection, defaults=(Any, Any))
+        return data_type(
+            (
+                _build_value(type_=key_type, data=key, config=config),
+                _build_value(type_=item_type, data=value, config=config),
+            )
+            for key, value in data.items()
+        )
     elif isinstance(data, tuple) and is_subclass(collection, tuple):
         if not data:
             return data_type()

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict
 
 import pytest
 
@@ -119,6 +119,16 @@ def test_from_dict_with_type_hook_exception():
 
     with pytest.raises(KeyError):
         from_dict(X, {"i": 1}, config=Config(type_hooks={int: raise_error}))
+
+
+def test_from_dict_with_type_hooks_and_generic_mapping():
+    @dataclass
+    class X:
+        d: Dict[str, str]
+
+    result = from_dict(X, {"d": {"B": "TEST"}}, config=Config(type_hooks={str: str.lower}))
+
+    assert result == X(d={"b": "test"})
 
 
 def test_from_dict_with_forward_reference():


### PR DESCRIPTION
Hi! 

Found a bug in your lib while migrating to a newer version. In version 1.6.0, type_hooks were applied to both dictionary keys and values. However, after upgrading to version 1.9.1, I noticed that type_hooks are no longer applied to dictionary keys, only to values.

This PR restores the previous behavior, ensuring that type_hooks are consistently applied to both dictionary keys and values, just like in version 1.6.0. This change should improve backward compatibility and maintain expected behavior for users relying on type_hooks.

Let me know if any adjustments or additional tests are needed!