### PR TITLE
Add support for type aliases using the "type" keyword

### DIFF
--- a/dacite/types.py
+++ b/dacite/types.py
@@ -1,3 +1,4 @@
+from sys import version_info
 from dataclasses import InitVar, is_dataclass
 from typing import Type, Any, Optional, Union, Collection, TypeVar, Mapping, Tuple, cast as typing_cast
 
@@ -135,6 +136,27 @@ def is_generic_dataclass(type_: Type) -> bool:
     return is_dataclass(get_origin(type_))
 
 
+if version_info >= (3, 12):  # TypeAliasType was introduced in version 3.12
+    from typing import TypeAliasType
+
+    @cache
+    def is_type_alias(type_) -> bool:
+        return isinstance(type_, TypeAliasType)
+
+    # "TypeAliasType.evaluate_value" was introduced in version 3.14
+    if version_info >= (3, 14):
+        @cache
+        def extract_type_alias(type_: TypeAliasType) -> Type:
+            return type_.evaluate_value()
+    else:
+        @cache
+        def extract_type_alias(type_: TypeAliasType) -> Type:
+            return type_.__value__
+else:
+    def is_type_alias(type_) -> bool:
+        return False
+
+
 def is_instance(value: Any, type_: Type) -> bool:
     try:
         # As described in PEP 484 - section: "The numeric tower"
@@ -178,4 +200,6 @@ def is_instance(value: Any, type_: Type) -> bool:
         return is_subclass(value, extract_generic(type_)[0])
     if is_generic_dataclass(type_):
         return isinstance(value, get_origin(type_))  # type: ignore[arg-type]
+    if is_type_alias(type_):
+        return is_instance(value, extract_type_alias(type_))
     return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from sys import version_info
+
+
+collect_ignore = []
+if version_info < (3, 12):
+    # The type alias tests use the "type" keyword, which was introduced in Python 3.12.
+    # Evaluating this file on older versions would cause a SyntaxError.
+    collect_ignore.append('core/test_type_alias.py')

--- a/tests/core/test_type_alias.py
+++ b/tests/core/test_type_alias.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+
+from dacite import from_dict
+from dacite.types import is_type_alias, extract_type_alias
+
+
+def test_is_type_alias():
+    type MyStr = str
+    assert is_type_alias(MyStr)
+
+
+def test_extract_type_alias():
+    type MyStr = str
+    assert extract_type_alias(MyStr) == str
+
+
+def test_from_dict_with_type_alias():
+    type MyStr = str
+
+    @dataclass
+    class X:
+        s: MyStr
+
+    result = from_dict(X, {"s": "foo"})
+
+    assert result == X(s="foo")

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -21,6 +21,7 @@ from dacite.types import (
     extract_init_var,
     is_type_generic,
     is_tuple,
+    is_type_alias
 )
 from tests.common import (
     literal_support,
@@ -410,3 +411,7 @@ def test_optional_and_union_none_does_not_pollute_scope_via_caching():
 @pep_604_support
 def test_optional_and_union_none_does_not_pollute_scope_via_caching_pep_604():
     is_generic_collection(str | None)
+
+
+def test_is_type_alias_with_non_type_alias():
+    assert not is_type_alias(str)


### PR DESCRIPTION
Starting from Python 3.12, it's possible to define a type alias using the following syntax:
```py
type MyAlias = str
```
This creates a `typing.TypeAliasType` object under the name `MyAlias`.

I added support for such type aliases, along with some tests.

I should note that some of the new tests (like `test_is_type_alias`) should've been added to `tests/test_types.py`. Instead, I placed them in `tests/core/test_type_alias.py`, because using the "type" keyword on Python versions older than 3.12 would raise a `SyntaxError` when the file is evaluated. Which is why the entire file `tests/core/test_type_alias.py` is excluded from testing on those older versions.